### PR TITLE
Coords everywhere in viewing area

### DIFF
--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -117,7 +117,7 @@ class MainWindow(QMainWindow):
 
         # Edit Menu
         self.applyAction = QAction("&Apply Changes", self)
-        self.applyAction.setShortcut("Shift+Return")
+        self.applyAction.setShortcut("Ctrl+Return")
         self.applyAction.setToolTip('Generate new view with changes applied')
         self.applyAction.setStatusTip('Generate new view with changes applied')
         self.applyAction.triggered.connect(self.applyChanges)
@@ -200,9 +200,28 @@ class MainWindow(QMainWindow):
         self.materialAction.triggered.connect(lambda :
             self.editColorBy('material', apply=True))
 
+        self.temperatureAction = QAction('&Temperature', self)
+        self.temperatureAction.setCheckable(True)
+        self.temperatureAction.setShortcut('Alt+T')
+        self.temperatureAction.setToolTip('Color by temperature')
+        self.temperatureAction.setStatusTip('Color plot by temperature')
+        self.temperatureAction.triggered.connect(lambda :
+            self.editColorBy('temperature', apply=True))
+
+        self.densityAction = QAction('&Density', self)
+        self.densityAction.setCheckable(True)
+        self.densityAction.setShortcut('Alt+D')
+        self.densityAction.setToolTip('Color by density')
+        self.densityAction.setStatusTip('Color plot by density')
+        self.densityAction.triggered.connect(lambda :
+            self.editColorBy('density', apply=True))
+
         self.colorbyMenu = self.editMenu.addMenu('&Color By')
         self.colorbyMenu.addAction(self.cellAction)
         self.colorbyMenu.addAction(self.materialAction)
+        self.colorbyMenu.addAction(self.temperatureAction)
+        self.colorbyMenu.addAction(self.densityAction)
+
         self.colorbyMenu.aboutToShow.connect(self.updateColorbyMenu)
 
         self.editMenu.addSeparator()
@@ -283,6 +302,8 @@ class MainWindow(QMainWindow):
         cv = self.model.currentView
         self.cellAction.setChecked(cv.colorby == 'cell')
         self.materialAction.setChecked(cv.colorby == 'material')
+        self.temperatureAction.setChecked(cv.colorby == 'temperature')
+        self.densityAction.setChecked(cv.colorby == 'density')
 
     def updateViewMenu(self):
         if self.dock.isVisible():

--- a/plotgui.py
+++ b/plotgui.py
@@ -669,6 +669,9 @@ class ColorDialog(QDialog):
         self.colorbyBox = QComboBox(self)
         self.colorbyBox.addItem("material")
         self.colorbyBox.addItem("cell")
+        self.colorbyBox.addItem("temperature")
+        self.colorbyBox.addItem("density")
+
         self.colorbyBox.currentTextChanged[str].connect(self.mw.editColorBy)
 
         formLayout = QFormLayout()

--- a/plotgui.py
+++ b/plotgui.py
@@ -80,7 +80,7 @@ class PlotImage(FigureCanvas):
         yPlotCoord = self.ax.dataLim.y0 + yPlotCoord * self.ax.dataLim.height
 
         # set coordinate label if pointer is in the axes
-        if self.ax.contains_point((pos.x(), pos.y())):
+        if self.parent.underMouse():
             self.mw.coord_label.show()
             self.mw.showCoords(xPlotCoord, yPlotCoord)
         else:

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -122,7 +122,7 @@ class PlotModel():
 
         cv = self.currentView = copy.deepcopy(self.activeView)
         ids = capi_plot.id_map(cv)
-        self.props = capi_plot.property_map(cv)
+        props = capi_plot.property_map(cv)
         # empty image data
         image = np.ones((cv.v_res, cv.h_res, 3), dtype = int)
 
@@ -164,6 +164,8 @@ class PlotModel():
 
         # set model image
         self.image = image
+        # set model properties
+        self.properties = props
 
     def undo(self):
         """ Revert to previous PlotView instance. Re-generate plot image """
@@ -215,7 +217,7 @@ class PlotView(_PlotBase):
         prevent image stretching/warping
     basis : {'xy', 'xz', 'yz'}
         The basis directions for the plot
-    colorby : {'cell', 'material'}
+    colorby : {'cell', 'material', 'temperature', 'density'}
         Indication of whether the plot should be colored by cell or material
     masking : bool
         Indication of whether cell/material masking is active


### PR DESCRIPTION
Small changes to show coordinates in viewing area even if the mouse is outside the image. This will help when selecting an area with a section outside the displayed image.