### PR TITLE
Show coords everywhere in viewing area.

### DIFF
--- a/plotgui.py
+++ b/plotgui.py
@@ -80,7 +80,7 @@ class PlotImage(FigureCanvas):
         yPlotCoord = self.ax.dataLim.y0 + yPlotCoord * self.ax.dataLim.height
 
         # set coordinate label if pointer is in the axes
-        if self.ax.contains_point((pos.x(), pos.y())):
+        if self.parent.underMouse():
             self.mw.coord_label.show()
             self.mw.showCoords(xPlotCoord, yPlotCoord)
         else:


### PR DESCRIPTION
Small changes to show coordinates in viewing area even if the mouse is outside the image. This will help when selecting an area with a section outside the displayed image.