### PR TITLE
Property Plotting

### DIFF
--- a/plot_colors.py
+++ b/plot_colors.py
@@ -10,8 +10,7 @@ def random_rgb():
 def rgb_normalize(rgb):
     return tuple([c/255. for c in rgb])
 
-def invert_rgb(rgb, normalized = False):
+def invert_rgb(rgb, normalized=False):
     rgb_max = 1.0 if normalized else 255.
     inv = [rgb_max - c for c in rgb[0:3]]
     return (*inv, *rgb[3:])
-    return inv

--- a/plot_colors.py
+++ b/plot_colors.py
@@ -9,3 +9,10 @@ def random_rgb():
 
 def rgb_normalize(rgb):
     return tuple([c/255. for c in rgb])
+
+def invert_rgb(rgb, normalized = False):
+    rgb_max = 1.0 if normalized else 255.
+    inv = [rgb_max - c for c in rgb[0:3]]
+    if len(rgb) > 3:
+        inv = (*inv, rgb[3])
+    return inv

--- a/plot_colors.py
+++ b/plot_colors.py
@@ -13,6 +13,5 @@ def rgb_normalize(rgb):
 def invert_rgb(rgb, normalized = False):
     rgb_max = 1.0 if normalized else 255.
     inv = [rgb_max - c for c in rgb[0:3]]
-    if len(rgb) > 3:
-        inv = (*inv, rgb[3])
+    return (*inv, *rgb[3:])
     return inv

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -440,7 +440,7 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
-    def editColorBarMin(self, min_val, property_type, apply=False):
+    def editColorbarMin(self, min_val, property_type, apply=False):
         current = self.model.activeView.user_minmax[property_type]
         self.model.activeView.user_minmax[property_type] = (min_val, current[1])
         self.colorDialog.updateColorMinMax()
@@ -448,7 +448,7 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
-    def editColorBarMax(self, max_val, property_type, apply=False):
+    def editColorbarMax(self, max_val, property_type, apply=False):
         current = self.model.activeView.user_minmax[property_type]
         self.model.activeView.user_minmax[property_type] = (current[0], max_val)
         self.colorDialog.updateColorMinMax()
@@ -456,13 +456,13 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
-    def toggleColorBarScale(self, state, property, apply=False):
+    def toggleColorbarScale(self, state, property, apply=False):
         av = self.model.activeView
         av.color_scale_log[property] = bool(state)
         # temporary, should be resolved diferently in the future
         cv = self.model.currentView
         cv.color_scale_log[property] = bool(state)
-        self.plotIm.updateColorBarScale()
+        self.plotIm.updateColorbarScale()
         if apply:
             self.applyChanges()
 
@@ -478,6 +478,10 @@ class MainWindow(QMainWindow):
     def toggleDataIndicatorCheckBox(self, state, property, apply=False):
         av = self.model.activeView
         av.data_indicator_enabled[property] = bool(state)
+
+        cv = self.model.currentView
+        cv.data_indicator_enabled[property] = bool(state)
+
         self.plotIm.updateDataIndicatorVisibility()
         if apply:
             self.applyChanges()

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -272,7 +272,6 @@ class MainWindow(QMainWindow):
         self.mainWindowAction.triggered.connect(self.showMainWindow)
 
         self.colorDialogAction = QAction('Color &Options', self)
-        self.colorDialogAction.setShortcut('Alt+D')
         self.colorDialogAction.setCheckable(True)
         self.colorDialogAction.setToolTip('Bring Color Dialog to front')
         self.colorDialogAction.setStatusTip('Bring Color Dialog to front')
@@ -427,6 +426,11 @@ class MainWindow(QMainWindow):
         self.model.activeView.colorby = domain_kind
         self.dock.updateColorBy()
         self.colorDialog.updateColorBy()
+        if apply:
+            self.applyChanges()
+
+    def editColorMap(self, colormap_name, property_type, apply=False):
+        self.plotIm.updateColorMap(colormap_name, property_type)
         if apply:
             self.applyChanges()
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -436,6 +436,13 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
+    def editColorBarMinMax(self, min_val, max_val, property_type, apply=False):
+        self.model.activeView.colorbar_minmax[property_type] = (min_val, max_val)
+        self.plotIm.updateColorMinMax(min_val, max_val, property_type)
+        self.colorDialog.updateColorMinMax()
+        if apply:
+            self.applyChanges()
+
     def toggleMasking(self, state, apply=False):
         self.model.activeView.masking = bool(state)
         self.colorDialog.updateMasking()

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -20,9 +20,9 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super(MainWindow, self).__init__()
 
-        openmc.capi.init(['-c'])
-
         self.setWindowTitle('OpenMC Plot Explorer')
+
+        openmc.capi.init(["-c"])
 
         self.restored = False
         self.pixmap = None
@@ -81,7 +81,6 @@ class MainWindow(QMainWindow):
     # Create and update menus:
     def createMenuBar(self):
         self.mainMenu = self.menuBar()
-
 
         # File Menu
         self.saveImageAction = QAction("&Save Image As...", self)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -10,7 +10,8 @@ import sys
 import openmc
 from PySide2 import QtCore, QtGui
 from PySide2.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
-    QScrollArea, QMenu, QAction, QFileDialog, QColorDialog, QInputDialog)
+                               QScrollArea, QMenu, QAction, QFileDialog,
+                               QColorDialog, QInputDialog)
 
 from plotmodel import PlotModel, DomainTableModel
 from plotgui import PlotImage, ColorDialog, OptionsDock
@@ -34,7 +35,6 @@ class MainWindow(QMainWindow):
 
         self.cellsModel = DomainTableModel(self.model.activeView.cells)
         self.materialsModel = DomainTableModel(self.model.activeView.materials)
-
 
         # Create viewing area
         self.frame = QScrollArea(self)
@@ -157,24 +157,24 @@ class MainWindow(QMainWindow):
         self.xyAction.setShortcut('Alt+X')
         self.xyAction.setToolTip('Change to xy basis')
         self.xyAction.setStatusTip('Change to xy basis')
-        self.xyAction.triggered.connect(lambda :
-            self.editBasis('xy', apply=True))
+        self.xyAction.triggered.connect(lambda:
+                                        self.editBasis('xy', apply=True))
 
         self.xzAction = QAction('x&z  ', self)
         self.xzAction.setCheckable(True)
         self.xzAction.setShortcut('Alt+Z')
         self.xzAction.setToolTip('Change to xz basis')
         self.xzAction.setStatusTip('Change to xz basis')
-        self.xzAction.triggered.connect(lambda :
-            self.editBasis('xz', apply=True))
+        self.xzAction.triggered.connect(lambda:
+                                        self.editBasis('xz', apply=True))
 
         self.yzAction = QAction('&yz  ', self)
         self.yzAction.setCheckable(True)
         self.yzAction.setShortcut('Alt+Y')
         self.yzAction.setToolTip('Change to yz basis')
         self.yzAction.setStatusTip('Change to yz basis')
-        self.yzAction.triggered.connect(lambda :
-            self.editBasis('yz', apply=True))
+        self.yzAction.triggered.connect(lambda:
+                                        self.editBasis('yz', apply=True))
 
         self.basisMenu = self.editMenu.addMenu('&Basis')
         self.basisMenu.addAction(self.xyAction)
@@ -188,32 +188,32 @@ class MainWindow(QMainWindow):
         self.cellAction.setShortcut('Alt+C')
         self.cellAction.setToolTip('Color by cell')
         self.cellAction.setStatusTip('Color plot by cell')
-        self.cellAction.triggered.connect(lambda :
-            self.editColorBy('cell', apply=True))
+        self.cellAction.triggered.connect(lambda:
+                                          self.editColorBy('cell', apply=True))
 
         self.materialAction = QAction('&Material', self)
         self.materialAction.setCheckable(True)
         self.materialAction.setShortcut('Alt+M')
         self.materialAction.setToolTip('Color by material')
         self.materialAction.setStatusTip('Color plot by material')
-        self.materialAction.triggered.connect(lambda :
-            self.editColorBy('material', apply=True))
+        self.materialAction.triggered.connect(lambda:
+                                              self.editColorBy('material', apply=True))
 
         self.temperatureAction = QAction('&Temperature', self)
         self.temperatureAction.setCheckable(True)
         self.temperatureAction.setShortcut('Alt+T')
         self.temperatureAction.setToolTip('Color by temperature')
         self.temperatureAction.setStatusTip('Color plot by temperature')
-        self.temperatureAction.triggered.connect(lambda :
-            self.editColorBy('temperature', apply=True))
+        self.temperatureAction.triggered.connect(lambda:
+                                                 self.editColorBy('temperature', apply=True))
 
         self.densityAction = QAction('&Density', self)
         self.densityAction.setCheckable(True)
         self.densityAction.setShortcut('Alt+D')
         self.densityAction.setToolTip('Color by density')
         self.densityAction.setStatusTip('Color plot by density')
-        self.densityAction.triggered.connect(lambda :
-            self.editColorBy('density', apply=True))
+        self.densityAction.triggered.connect(lambda:
+                                             self.editColorBy('density', apply=True))
 
         self.colorbyMenu = self.editMenu.addMenu('&Color By')
         self.colorbyMenu.addAction(self.cellAction)
@@ -231,7 +231,7 @@ class MainWindow(QMainWindow):
         self.maskingAction.setToolTip('Toggle masking')
         self.maskingAction.setStatusTip('Toggle whether masking is enabled')
         self.maskingAction.triggered[bool].connect(lambda bool=bool:
-            self.toggleMasking(bool, apply=True))
+                                                   self.toggleMasking(bool, apply=True))
         self.editMenu.addAction(self.maskingAction)
 
         self.highlightingAct = QAction('Enable High&lighting', self)
@@ -240,7 +240,7 @@ class MainWindow(QMainWindow):
         self.highlightingAct.setToolTip('Toggle highlighting')
         self.highlightingAct.setStatusTip('Toggle whether highlighting is enabled')
         self.highlightingAct.triggered[bool].connect(lambda bool=bool:
-            self.toggleHighlighting(bool, apply=True))
+                                                     self.toggleHighlighting(bool, apply=True))
         self.editMenu.addAction(self.highlightingAct)
 
         # View Menu
@@ -316,8 +316,10 @@ class MainWindow(QMainWindow):
     # Menu and shared methods:
 
     def saveImage(self):
-        filename, ext = QFileDialog.getSaveFileName(self, "Save Plot Image",
-                                         "untitled", "Images (*.png *.ppm)")
+        filename, ext = QFileDialog.getSaveFileName(self,
+                                                    "Save Plot Image",
+                                                    "untitled",
+                                                    "Images (*.png)")
         if filename:
             if "." not in filename:
                 filename += ".png"
@@ -327,15 +329,16 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage('Plot Image Saved', 5000)
 
     def saveView(self):
-        filename, ext = QFileDialog.getSaveFileName(self, "Save View Settings",
-                                        "untitled", "View Settings (*.pltvw)")
+        filename, ext = QFileDialog.getSaveFileName(self,
+                                                    "Save View Settings",
+                                                    "untitled",
+                                                    "View Settings (*.pltvw)")
         if filename:
             if "." not in filename:
                 filename += ".pltvw"
 
-            saved = {'version' : self.model.version,
+            saved = {'version': self.model.version,
                      'current': self.model.currentView}
-
             with open(filename, 'wb') as file:
                 pickle.dump(saved, file)
 
@@ -598,7 +601,7 @@ class MainWindow(QMainWindow):
     # Plot image methods
 
     def editPlotOrigin(self, xOr, yOr, zOr=None, apply=False):
-        if zOr != None:
+        if zOr is not None:
             self.model.activeView.origin = [xOr, yOr, zOr]
         else:
             origin = [None, None, None]
@@ -658,13 +661,19 @@ class MainWindow(QMainWindow):
     def restoreWindowSettings(self):
         settings = QtCore.QSettings()
 
-        self.resize(settings.value("mainWindow/Size", QtCore.QSize(800,600)))
-        self.move(settings.value("mainWindow/Position", QtCore.QPoint(100,100)))
+        self.resize(settings.value("mainWindow/Size",
+                                   QtCore.QSize(800, 600)))
+        self.move(settings.value("mainWindow/Position",
+                                 QtCore.QPoint(100, 100)))
         self.restoreState(settings.value("mainWindow/State"))
 
-        self.colorDialog.resize(settings.value("colorDialog/Size", QtCore.QSize(400, 500)))
-        self.colorDialog.move(settings.value("colorDialog/Position", QtCore.QPoint(600, 200)))
-        self.colorDialog.setVisible(bool(int(settings.value("colorDialog/Visible", 0))))
+        self.colorDialog.resize(settings.value("colorDialog/Size",
+                                               QtCore.QSize(400, 500)))
+        self.colorDialog.move(settings.value("colorDialog/Position",
+                                             QtCore.QPoint(600, 200)))
+        is_visible = settings.value("colorDialog/Visible", 0)
+        is_visible = bool(int(is_visible))
+        self.colorDialog.setVisible(is_visible)
 
     def restoreModelSettings(self):
         if os.path.isfile("plot_settings.pkl"):
@@ -678,7 +687,7 @@ class MainWindow(QMainWindow):
                 self.model.previousViews = model.previousViews
                 self.model.subsequentViews = model.subsequentViews
                 if os.path.isfile('plot_ids.binary') \
-                    and os.path.isfile('plot.ppm'):
+                   and os.path.isfile('plot.ppm'):
                     self.restored = True
 
     def resetModels(self):
@@ -715,6 +724,7 @@ class MainWindow(QMainWindow):
         self.xBasis = 0 if cv.basis[0] == 'x' else 1
         self.yBasis = 1 if cv.basis[1] == 'y' else 2
         self.zBasis = 3 - (self.xBasis + self.yBasis)
+
     def adjustWindow(self):
         self.screen = app.desktop().screenGeometry()
         self.setMaximumSize(self.screen.width(), self.screen.height())

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -475,8 +475,8 @@ class MainWindow(QMainWindow):
 
     def toggleDataIndicatorCheckBox(self, state, property, apply=False):
         av = self.model.activeView
-        av.dataindicator_enabled[property] = bool(state)
-        self.plotIm.updateDataindicatorVisibility()
+        av.data_indicator_enabled[property] = bool(state)
+        self.plotIm.updateDataIndicatorVisibility()
         if apply:
             self.applyChanges()
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -430,7 +430,9 @@ class MainWindow(QMainWindow):
             self.applyChanges()
 
     def editColorMap(self, colormap_name, property_type, apply=False):
+        self.model.activeView.colormaps[property_type] = colormap_name
         self.plotIm.updateColorMap(colormap_name, property_type)
+        self.colorDialog.updateColorMaps()
         if apply:
             self.applyChanges()
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -322,6 +322,8 @@ class MainWindow(QMainWindow):
         if filename:
             if "." not in filename:
                 filename += ".png"
+            if self.plotIm.data_line:
+                self.plotIm.data_line.set_visible(False)
             self.plotIm.figure.savefig(filename, transparent=True)
             self.statusBar().showMessage('Plot Image Saved', 5000)
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import copy
+from functools import partial
 import os
 from pathlib import Path
 import pickle
@@ -157,24 +158,24 @@ class MainWindow(QMainWindow):
         self.xyAction.setShortcut('Alt+X')
         self.xyAction.setToolTip('Change to xy basis')
         self.xyAction.setStatusTip('Change to xy basis')
-        self.xyAction.triggered.connect(lambda:
-                                        self.editBasis('xy', apply=True))
+        xy_connector = partial(self.editBasis, 'xy', apply=True)
+        self.xyAction.triggered.connect(xy_connector)
 
         self.xzAction = QAction('x&z  ', self)
         self.xzAction.setCheckable(True)
         self.xzAction.setShortcut('Alt+Z')
         self.xzAction.setToolTip('Change to xz basis')
         self.xzAction.setStatusTip('Change to xz basis')
-        self.xzAction.triggered.connect(lambda:
-                                        self.editBasis('xz', apply=True))
+        xz_connector = partial(self.editBasis, 'xz', apply=True)
+        self.xzAction.triggered.connect(xz_connector)
 
         self.yzAction = QAction('&yz  ', self)
         self.yzAction.setCheckable(True)
         self.yzAction.setShortcut('Alt+Y')
         self.yzAction.setToolTip('Change to yz basis')
         self.yzAction.setStatusTip('Change to yz basis')
-        self.yzAction.triggered.connect(lambda:
-                                        self.editBasis('yz', apply=True))
+        yz_connector = partial(self.editBasis, 'yz', apply=True)
+        self.yzAction.triggered.connect(yz_connector)
 
         self.basisMenu = self.editMenu.addMenu('&Basis')
         self.basisMenu.addAction(self.xyAction)
@@ -188,32 +189,32 @@ class MainWindow(QMainWindow):
         self.cellAction.setShortcut('Alt+C')
         self.cellAction.setToolTip('Color by cell')
         self.cellAction.setStatusTip('Color plot by cell')
-        self.cellAction.triggered.connect(lambda:
-                                          self.editColorBy('cell', apply=True))
+        cell_connector = partial(self.editColorBy, 'cell', apply=True)
+        self.cellAction.triggered.connect(cell_connector)
 
         self.materialAction = QAction('&Material', self)
         self.materialAction.setCheckable(True)
         self.materialAction.setShortcut('Alt+M')
         self.materialAction.setToolTip('Color by material')
         self.materialAction.setStatusTip('Color plot by material')
-        self.materialAction.triggered.connect(lambda:
-                                              self.editColorBy('material', apply=True))
+        material_connector = partial(self.editColorBy, 'material', apply=True)
+        self.materialAction.triggered.connect(material_connector)
 
         self.temperatureAction = QAction('&Temperature', self)
         self.temperatureAction.setCheckable(True)
         self.temperatureAction.setShortcut('Alt+T')
         self.temperatureAction.setToolTip('Color by temperature')
         self.temperatureAction.setStatusTip('Color plot by temperature')
-        self.temperatureAction.triggered.connect(lambda:
-                                                 self.editColorBy('temperature', apply=True))
+        temp_connector = partial(self.editColorBy, 'temperature', apply=True)
+        self.temperatureAction.triggered.connect(temp_connector)
 
         self.densityAction = QAction('&Density', self)
         self.densityAction.setCheckable(True)
         self.densityAction.setShortcut('Alt+D')
         self.densityAction.setToolTip('Color by density')
         self.densityAction.setStatusTip('Color plot by density')
-        self.densityAction.triggered.connect(lambda:
-                                             self.editColorBy('density', apply=True))
+        density_connector = partial(self.editColorBy, 'density', apply=True)
+        self.densityAction.triggered.connect(density_connector)
 
         self.colorbyMenu = self.editMenu.addMenu('&Color By')
         self.colorbyMenu.addAction(self.cellAction)
@@ -230,8 +231,8 @@ class MainWindow(QMainWindow):
         self.maskingAction.setCheckable(True)
         self.maskingAction.setToolTip('Toggle masking')
         self.maskingAction.setStatusTip('Toggle whether masking is enabled')
-        self.maskingAction.triggered[bool].connect(lambda bool=bool:
-                                                   self.toggleMasking(bool, apply=True))
+        masking_connector = partial(self.toggleMasking, apply=True)
+        self.maskingAction.toggled.connect(masking_connector)
         self.editMenu.addAction(self.maskingAction)
 
         self.highlightingAct = QAction('Enable High&lighting', self)
@@ -239,8 +240,8 @@ class MainWindow(QMainWindow):
         self.highlightingAct.setCheckable(True)
         self.highlightingAct.setToolTip('Toggle highlighting')
         self.highlightingAct.setStatusTip('Toggle whether highlighting is enabled')
-        self.highlightingAct.triggered[bool].connect(lambda bool=bool:
-                                                     self.toggleHighlighting(bool, apply=True))
+        highlight_connector = partial(self.toggleHighlighting, apply=True)
+        self.highlightingAct.toggled.connect(highlight_connector)
         self.editMenu.addAction(self.highlightingAct)
 
         # View Menu

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -438,9 +438,18 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
-    def editColorBarMinMax(self, min_val, max_val, property_type, apply=False):
-        self.model.activeView.colorbar_minmax[property_type] = (min_val, max_val)
-        self.plotIm.updateColorMinMax(min_val, max_val, property_type)
+    def editColorBarMin(self, min_val, property_type, apply=False):
+        current = self.model.activeView.colorbar_minmax[property_type]
+        self.model.activeView.colorbar_minmax[property_type] = (min_val, current[1])
+        self.plotIm.updateColorMinMax(property_type)
+        self.colorDialog.updateColorMinMax()
+        if apply:
+            self.applyChanges()
+
+    def editColorBarMax(self, max_val, property_type, apply=False):
+        current = self.model.activeView.colorbar_minmax[property_type]
+        self.model.activeView.colorbar_minmax[property_type] = (current[0], max_val)
+        self.plotIm.updateColorMinMax(property_type)
         self.colorDialog.updateColorMinMax()
         if apply:
             self.applyChanges()

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -323,8 +323,6 @@ class MainWindow(QMainWindow):
         if filename:
             if "." not in filename:
                 filename += ".png"
-            if self.plotIm.data_line:
-                self.plotIm.data_line.set_visible(False)
             self.plotIm.figure.savefig(filename, transparent=True)
             self.statusBar().showMessage('Plot Image Saved', 5000)
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -464,10 +464,10 @@ class MainWindow(QMainWindow):
         self.plotIm.updateColorMinMax('density')
         self.colorDialog.updateColorMinMax()
 
-    def toggleDataLineCheckBox(self, state, property, apply=False):
+    def toggleDataindicatorCheckBox(self, state, property, apply=False):
         av = self.model.activeView
-        av.dataline_enabled[property] = bool(state)
-        self.plotIm.updateDataLineVisibility()
+        av.dataindicator_enabled[property] = bool(state)
+        self.plotIm.updateDataindicatorVisibility()
         if apply:
             self.applyChanges()
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -354,6 +354,7 @@ class MainWindow(QMainWindow):
             if saved['version'] == self.model.version:
                 self.model.activeView = saved['current']
                 self.dock.updateDock()
+                self.colorDialog.updateDialogValues()
                 self.applyChanges()
                 message = f'{filename} settings loaded'
             else:
@@ -441,16 +442,16 @@ class MainWindow(QMainWindow):
     def editColorBarMin(self, min_val, property_type, apply=False):
         current = self.model.activeView.user_minmax[property_type]
         self.model.activeView.user_minmax[property_type] = (min_val, current[1])
-        self.plotIm.updateColorMinMax(property_type)
         self.colorDialog.updateColorMinMax()
+        self.plotIm.updateColorMinMax(property_type)
         if apply:
             self.applyChanges()
 
     def editColorBarMax(self, max_val, property_type, apply=False):
         current = self.model.activeView.user_minmax[property_type]
         self.model.activeView.user_minmax[property_type] = (current[0], max_val)
-        self.plotIm.updateColorMinMax(property_type)
         self.colorDialog.updateColorMinMax()
+        self.plotIm.updateColorMinMax(property_type)
         if apply:
             self.applyChanges()
 
@@ -462,6 +463,13 @@ class MainWindow(QMainWindow):
         self.plotIm.updateColorMinMax('temperature')
         self.plotIm.updateColorMinMax('density')
         self.colorDialog.updateColorMinMax()
+
+    def toggleDataLineCheckBox(self, state, property, apply=False):
+        av = self.model.activeView
+        av.dataline_enabled[property] = bool(state)
+        self.plotIm.updateDataLineVisibility()
+        if apply:
+            self.applyChanges()
 
     def toggleMasking(self, state, apply=False):
         self.model.activeView.masking = bool(state)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -439,20 +439,29 @@ class MainWindow(QMainWindow):
             self.applyChanges()
 
     def editColorBarMin(self, min_val, property_type, apply=False):
-        current = self.model.activeView.colorbar_minmax[property_type]
-        self.model.activeView.colorbar_minmax[property_type] = (min_val, current[1])
+        current = self.model.activeView.user_minmax[property_type]
+        self.model.activeView.user_minmax[property_type] = (min_val, current[1])
         self.plotIm.updateColorMinMax(property_type)
         self.colorDialog.updateColorMinMax()
         if apply:
             self.applyChanges()
 
     def editColorBarMax(self, max_val, property_type, apply=False):
-        current = self.model.activeView.colorbar_minmax[property_type]
-        self.model.activeView.colorbar_minmax[property_type] = (current[0], max_val)
+        current = self.model.activeView.user_minmax[property_type]
+        self.model.activeView.user_minmax[property_type] = (current[0], max_val)
         self.plotIm.updateColorMinMax(property_type)
         self.colorDialog.updateColorMinMax()
         if apply:
             self.applyChanges()
+
+    def toggleUserMinMax(self, state, property):
+        av = self.model.activeView
+        av.use_custom_minmax[property] = bool(state)
+        if av.user_minmax[property] == (0.0, 0.0):
+            self.model.activeView.user_minmax[property] = copy.copy(av.data_minmax[property])
+        self.plotIm.updateColorMinMax('temperature')
+        self.plotIm.updateColorMinMax('density')
+        self.colorDialog.updateColorMinMax()
 
     def toggleMasking(self, state, apply=False):
         self.model.activeView.masking = bool(state)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -117,7 +117,7 @@ class MainWindow(QMainWindow):
 
         # Edit Menu
         self.applyAction = QAction("&Apply Changes", self)
-        self.applyAction.setShortcut("Shift+Return")
+        self.applyAction.setShortcut("Ctrl+Return")
         self.applyAction.setToolTip('Generate new view with changes applied')
         self.applyAction.setStatusTip('Generate new view with changes applied')
         self.applyAction.triggered.connect(self.applyChanges)
@@ -200,9 +200,28 @@ class MainWindow(QMainWindow):
         self.materialAction.triggered.connect(lambda :
             self.editColorBy('material', apply=True))
 
+        self.temperatureAction = QAction('&Temperature', self)
+        self.temperatureAction.setCheckable(True)
+        self.temperatureAction.setShortcut('Alt+T')
+        self.temperatureAction.setToolTip('Color by temperature')
+        self.temperatureAction.setStatusTip('Color plot by temperature')
+        self.temperatureAction.triggered.connect(lambda :
+            self.editColorBy('temperature', apply=True))
+
+        self.densityAction = QAction('&Density', self)
+        self.densityAction.setCheckable(True)
+        self.densityAction.setShortcut('Alt+D')
+        self.densityAction.setToolTip('Color by density')
+        self.densityAction.setStatusTip('Color plot by density')
+        self.densityAction.triggered.connect(lambda :
+            self.editColorBy('density', apply=True))
+
         self.colorbyMenu = self.editMenu.addMenu('&Color By')
         self.colorbyMenu.addAction(self.cellAction)
         self.colorbyMenu.addAction(self.materialAction)
+        self.colorbyMenu.addAction(self.temperatureAction)
+        self.colorbyMenu.addAction(self.densityAction)
+
         self.colorbyMenu.aboutToShow.connect(self.updateColorbyMenu)
 
         self.editMenu.addSeparator()
@@ -283,6 +302,8 @@ class MainWindow(QMainWindow):
         cv = self.model.currentView
         self.cellAction.setChecked(cv.colorby == 'cell')
         self.materialAction.setChecked(cv.colorby == 'material')
+        self.temperatureAction.setChecked(cv.colorby == 'temperature')
+        self.densityAction.setChecked(cv.colorby == 'density')
 
     def updateViewMenu(self):
         if self.dock.isVisible():

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -458,8 +458,11 @@ class MainWindow(QMainWindow):
             self.applyChanges()
 
     def toggleColorBarScale(self, state, property, apply=False):
-        av = self.model.currentView
+        av = self.model.activeView
         av.color_scale_log[property] = bool(state)
+        # temporary, should be resolved diferently in the future
+        cv = self.model.currentView
+        cv.color_scale_log[property] = bool(state)
         self.plotIm.updateColorBarScale()
         if apply:
             self.applyChanges()

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -454,6 +454,13 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
+    def toggleColorBarScale(self, state, property, apply=False):
+        av = self.model.currentView
+        av.color_scale_log[property] = bool(state)
+        self.plotIm.updateColorBarScale()
+        if apply:
+            self.applyChanges()
+
     def toggleUserMinMax(self, state, property):
         av = self.model.activeView
         av.use_custom_minmax[property] = bool(state)
@@ -463,7 +470,7 @@ class MainWindow(QMainWindow):
         self.plotIm.updateColorMinMax('density')
         self.colorDialog.updateColorMinMax()
 
-    def toggleDataindicatorCheckBox(self, state, property, apply=False):
+    def toggleDataIndicatorCheckBox(self, state, property, apply=False):
         av = self.model.activeView
         av.dataindicator_enabled[property] = bool(state)
         self.plotIm.updateDataindicatorVisibility()

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -289,8 +289,8 @@ class MainWindow(QMainWindow):
         self.maskingAction.setChecked(self.model.currentView.masking)
         self.highlightingAct.setChecked(self.model.currentView.highlighting)
 
-        self.undoAction.setText(f'&Undo ({len(self.model.previousViews)})')
-        self.redoAction.setText(f'&Redo ({len(self.model.subsequentViews)})')
+        self.undoAction.setText('&Undo ({})'.format(len(self.model.previousViews)))
+        self.redoAction.setText('&Redo ({})'.format(len(self.model.subsequentViews)))
 
     def updateBasisMenu(self):
         self.xyAction.setChecked(self.model.currentView.basis == 'xy')
@@ -357,7 +357,7 @@ class MainWindow(QMainWindow):
                 self.dock.updateDock()
                 self.colorDialog.updateDialogValues()
                 self.applyChanges()
-                message = f'{filename} settings loaded'
+                message = '{} settings loaded'.format(filename)
             else:
                 message = 'Error loading plot settings. Incompatible model.'
             self.statusBar().showMessage(message, 5000)
@@ -745,15 +745,18 @@ class MainWindow(QMainWindow):
     def showCoords(self, xPlotPos, yPlotPos):
         cv = self.model.currentView
         if cv.basis == 'xy':
-            coords = (f"({round(xPlotPos, 2)}, {round(yPlotPos, 2)}, "
-                      f"{round(cv.origin[2], 2)})")
+            coords = ("({}, {}, {})".format(round(xPlotPos, 2),
+                                            round(yPlotPos, 2),
+                                            round(cv.origin[2], 2)))
         elif cv.basis == 'xz':
-            coords = (f"({round(xPlotPos, 2)}, {round(cv.origin[1], 2)}, "
-                      f"{round(yPlotPos, 2)})")
+            coords = ("({}, {}, {})".format(round(xPlotPos, 2),
+                                            round(cv.origin[1], 2),
+                                            round(yPlotPos, 2)))
         else:
-            coords = (f"({round(cv.origin[0], 2)}, {round(xPlotPos, 2)}, "
-                      f"{round(yPlotPos, 2)})")
-        self.coord_label.setText(f'{coords}')
+            coords = ("({}, {}, {})".format(round(cv.origin[0], 2),
+                                            round(xPlotPos, 2),
+                                            round(yPlotPos, 2)))
+        self.coord_label.setText('{}'.format(coords))
 
     def resizePixmap(self):
         z = self.zoom / 100.

--- a/plotgui.py
+++ b/plotgui.py
@@ -411,7 +411,7 @@ class PlotImage(FigureCanvas):
 
         self.draw()
 
-    def updateColorBarScale(self):
+    def updateColorbarScale(self):
         self.setPixmap()
 
     def updateDataIndicatorValue(self, y_val):
@@ -432,9 +432,9 @@ class PlotImage(FigureCanvas):
             self.draw()
 
     def updateDataIndicatorVisibility(self):
-        av = self.model.activeView
+        cv = self.model.currentView
         if self.data_indicator and av.colorby in _MODEL_PROPERTIES:
-            val = av.data_indicator_enabled[av.colorby]
+            val = cv.data_indicator_enabled[cv.colorby]
             self.data_indicator.set_visible(val)
             self.draw()
 
@@ -860,7 +860,7 @@ class ColorDialog(QDialog):
         for key, val, in custom_minmax.items():
             self.tabs[key].minMaxCheckBox.setChecked(val)
 
-    def updateColorBarScale(self):
+    def updateColorbarScale(self):
         av = self.model.activeView
         for key, val in av.color_scale_log.items():
             self.tabs[key].colorBarScaleCheckBox.setChecked(val)
@@ -883,10 +883,10 @@ class ColorDialog(QDialog):
         propertyTab.maxBox.setMaximum(1E9)
         propertyTab.maxBox.setMinimum(0)
 
-        connector2 = partial(self.mw.editColorBarMin,
+        connector2 = partial(self.mw.editColorbarMin,
                              property_type=property_kind)
         propertyTab.minBox.valueChanged.connect(connector2)
-        connector3 = partial(self.mw.editColorBarMax,
+        connector3 = partial(self.mw.editColorbarMax,
                              property_type=property_kind)
         propertyTab.maxBox.valueChanged.connect(connector3)
 
@@ -907,7 +907,7 @@ class ColorDialog(QDialog):
 
         propertyTab.colorBarScaleCheckBox = QCheckBox()
         propertyTab.colorBarScaleCheckBox.setCheckable(True)
-        connector5 = partial(self.mw.toggleColorBarScale,
+        connector5 = partial(self.mw.toggleColorbarScale,
                              property=property_kind)
         propertyTab.colorBarScaleCheckBox.stateChanged.connect(connector5)
 
@@ -950,7 +950,7 @@ class ColorDialog(QDialog):
         self.updateMaskingColor()
         self.updateColorMaps()
         self.updateColorMinMax()
-        self.updateColorBarScale()
+        self.updateColorbarScale()
         self.updateDataIndicatorVisibility()
         self.updateHighlighting()
         self.updateHighlightColor()

--- a/plotgui.py
+++ b/plotgui.py
@@ -433,7 +433,7 @@ class PlotImage(FigureCanvas):
 
     def updateDataIndicatorVisibility(self):
         cv = self.model.currentView
-        if self.data_indicator and av.colorby in _MODEL_PROPERTIES:
+        if self.data_indicator and cv.colorby in _MODEL_PROPERTIES:
             val = cv.data_indicator_enabled[cv.colorby]
             self.data_indicator.set_visible(val)
             self.draw()
@@ -450,7 +450,7 @@ class PlotImage(FigureCanvas):
         if self.colorbar and property_type == av.colorby:
             clim = av.getColorLimits(property_type)
             self.colorbar.set_clim(*clim)
-            self.data_indicator.set_data((clim[0], clim[1]),
+            self.data_indicator.set_data(clim[:2],
                                          (0.0, 0.0))
             self.colorbar.draw_all()
             self.draw()

--- a/plotgui.py
+++ b/plotgui.py
@@ -669,6 +669,9 @@ class ColorDialog(QDialog):
         self.colorbyBox = QComboBox(self)
         self.colorbyBox.addItem("material")
         self.colorbyBox.addItem("cell")
+        self.colorbyBox.addItem("temperature")
+        self.colorbyBox.addItem("density")
+
         self.colorbyBox.currentTextChanged[str].connect(self.mw.editColorBy)
 
         formLayout = QFormLayout()

--- a/plotgui.py
+++ b/plotgui.py
@@ -243,7 +243,13 @@ class PlotImage(FigureCanvas):
 
         id, properties, domain, domain_kind = self.getIDinfo(event)
 
-        if id != str(_NOT_FOUND):
+        # always provide undo option
+        self.menu.addSeparator()
+        self.menu.addAction(self.mw.undoAction)
+        self.menu.addAction(self.mw.redoAction)
+        self.menu.addSeparator()
+
+        if id != str(_NOT_FOUND) and domain_kind.lower() not in ('density', 'temperature'):
 
             # Domain ID
             domainID = self.menu.addAction(f"{domain_kind} {id}")
@@ -253,11 +259,6 @@ class PlotImage(FigureCanvas):
             if domain[id].name:
                 domainName = self.menu.addAction(domain[id].name)
                 domainName.setDisabled(True)
-
-            self.menu.addSeparator()
-            self.menu.addAction(self.mw.undoAction)
-            self.menu.addAction(self.mw.redoAction)
-            self.menu.addSeparator()
 
             colorAction = self.menu.addAction(f'Edit {domain_kind} Color...')
             colorAction.setDisabled(self.model.currentView.highlighting)
@@ -302,9 +303,10 @@ class PlotImage(FigureCanvas):
         self.menu.addMenu(self.mw.basisMenu)
         self.menu.addMenu(self.mw.colorbyMenu)
         self.menu.addSeparator()
-        self.menu.addAction(self.mw.maskingAction)
-        self.menu.addAction(self.mw.highlightingAct)
-        self.menu.addSeparator()
+        if domain_kind.lower() not in ('density', 'temperature'):
+            self.menu.addAction(self.mw.maskingAction)
+            self.menu.addAction(self.mw.highlightingAct)
+            self.menu.addSeparator()
         self.menu.addAction(self.mw.dockAction)
 
         self.mw.maskingAction.setChecked(self.model.currentView.masking)

--- a/plotgui.py
+++ b/plotgui.py
@@ -16,14 +16,13 @@ from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
                                QFileDialog, QDialog, QTabWidget, QGridLayout,
                                QToolButton, QColorDialog, QFrame, QDockWidget,
                                QTableView, QItemDelegate, QHeaderView, QSlider)
+import matplotlib.pyplot as plt
 from matplotlib.backends.qt_compat import is_pyqt5
 from matplotlib.figure import Figure
 from matplotlib import image as mpimage
 from matplotlib import lines as mlines
 from matplotlib import cm as mcolormaps
 from matplotlib.colors import SymLogNorm, NoNorm
-
-import matplotlib.pyplot as plt
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import (
@@ -274,7 +273,7 @@ class PlotImage(FigureCanvas):
             colorAction.setToolTip(f'Edit {domain_kind} color')
             colorAction.setStatusTip(f'Edit {domain_kind} color')
             colorAction.triggered.connect(lambda:
-                self.mw.editDomainColor(domain_kind, id))
+                                          self.mw.editDomainColor(domain_kind, id))
 
             maskAction = self.menu.addAction(f'Mask {domain_kind}')
             maskAction.setCheckable(True)
@@ -283,7 +282,7 @@ class PlotImage(FigureCanvas):
             maskAction.setToolTip(f'Toggle {domain_kind} mask')
             maskAction.setStatusTip(f'Toggle {domain_kind} mask')
             maskAction.triggered[bool].connect(lambda bool=bool:
-                self.mw.toggleDomainMask(bool, domain_kind, id))
+                                               self.mw.toggleDomainMask(bool, domain_kind, id))
 
             highlightAction = self.menu.addAction(f'Highlight {domain_kind}')
             highlightAction.setCheckable(True)
@@ -292,7 +291,7 @@ class PlotImage(FigureCanvas):
             highlightAction.setToolTip(f'Toggle {domain_kind} highlight')
             highlightAction.setStatusTip(f'Toggle {domain_kind} highlight')
             highlightAction.triggered[bool].connect(lambda bool=bool:
-                self.mw.toggleDomainHighlight(bool, domain_kind, id))
+                                                    self.mw.toggleDomainHighlight(bool, domain_kind, id))
 
         else:
             self.menu.addAction(self.mw.undoAction)
@@ -410,17 +409,17 @@ class PlotImage(FigureCanvas):
         self.setPixmap()
 
     def updateDataIndicatorValue(self, y_val):
-        av = self.model.currentView
+        cv = self.model.currentView
+
+        if cv.colorby not in _MODEL_PROPERTIES or \
+           not cv.data_indicator_enabled[cv.colorby]:
+            return
+
         if self.data_indicator:
             data = self.data_indicator.get_data()
-            if av.color_scale_log[av.colorby]:
-                print(y_val)
-                trans = self.colorbar.ax.transData + \
-                        self.colorbar.ax.transAxes.inverted()
-                print(y_val)
-                _, y_val = trans.transform((0.0, y_val))
-                y_val  = 1 - y_val
-                print(y_val)
+            # use norm to get axis value if log scale
+            if cv.color_scale_log[cv.colorby]:
+                y_val = self.image.norm(y_val)
             self.data_indicator.set_data([data[0], [y_val, y_val]])
             dl_color = invert_rgb(self.colorbar.get_cmap()(y_val), True)
             self.data_indicator.set_c(dl_color)
@@ -838,8 +837,8 @@ class ColorDialog(QDialog):
     def updateColorMaps(self):
         cmaps = self.model.activeView.colormaps
         for key, val in cmaps.items():
-            idx= self.tabs[key].colormapBox.findText(val,
-                                                     QtCore.Qt.MatchFixedString)
+            idx = self.tabs[key].colormapBox.findText(val,
+                                                      QtCore.Qt.MatchFixedString)
             if idx >= 0:
                 self.tabs[key].colormapBox.setCurrentIndex(idx)
 

--- a/plotgui.py
+++ b/plotgui.py
@@ -52,8 +52,6 @@ class PlotImage(FigureCanvas):
         self.colorbar = None
         self.data_line = None
         self.image = None
-        self.colormap_temp = 'Oranges'
-        self.colormap_density = 'Greys'
 
         self.menu = QMenu(self)
 
@@ -345,20 +343,19 @@ class PlotImage(FigureCanvas):
                                               extent=data_bounds,
                                               alpha=cv.plotAlpha)
         else:
+            cmap = cv.colormaps[cv.colorby]
             if cv.colorby == 'temperature':
                 idx = 0
-                cmap = self.colormap_temp
                 cmap_label = "Temperature (K)"
             else:
                 idx = 1
-                cmap = self.colormap_density
                 cmap_label = "Density (g/ccm)"
 
             self.image = self.figure.subplots().imshow(self.model.properties[:,:,idx],
                                               cmap=cmap,
                                               extent=data_bounds,
                                               alpha=cv.plotAlpha)
-            cmap_ax = self.figure.add_axes([0.95, 0.1, 0.03, 0.8])
+            cmap_ax = self.figure.add_axes([0.9, 0.1, 0.03, 0.8])
             # add colorbar
             self.colorbar = self.figure.colorbar(self.image,
                                                  cax=cmap_ax,
@@ -394,11 +391,6 @@ class PlotImage(FigureCanvas):
             self.draw()
 
     def updateColorMap(self, colormap_name, property_type):
-        if property_type == 'temperature':
-            self.colormap_temp = colormap_name
-        else:
-            self.colormap_density = colormap_name
-
         if self.colorbar and property_type == self.model.activeView.colorby:
             self.colorbar.set_cmap(colormap_name)
             self.image.set_cmap(colormap_name)
@@ -785,15 +777,14 @@ class ColorDialog(QDialog):
 
         return domainTab
 
-    def editColorMap(self, colormap_name):
-        self.mw.editColorMap(colormap_name, self.property_kind)
-
-    def updateColorMap(self, colormap_name, property_type):
-        if property_type == 'temperature':
-            self.temperatureTab.colormapBox.setValue(colormap_name)
-        else:
-            self.densityTab.colormapBox.setValue(colormap_name)
-
+    def updateColorMaps(self):
+        colormaps = self.model.activeView.colormaps
+        index = self.densityTab.colormapBox.findText(colormaps['density'], QtCore.Qt.MatchFixedString)
+        if index >= 0:
+            self.densityTab.colormapBox.setCurrentIndex(index)
+        index = self.densityTab.colormapBox.findText(colormaps['temperature'], QtCore.Qt.MatchFixedString)
+        if index >= 0:
+            self.temperatureTab.colormapBox.setCurrentIndex(index)
 
     def createPropertyTab(self, property_kind):
 
@@ -818,7 +809,6 @@ class ColorDialog(QDialog):
 
         formLayout.addRow('Colormap:', propertyTab.colormapBox)
 
-
         propertyTab.setLayout(formLayout)
 
         return propertyTab
@@ -842,6 +832,7 @@ class ColorDialog(QDialog):
 
         self.updateMasking()
         self.updateMaskingColor()
+        self.updateColorMaps()
         self.updateHighlighting()
         self.updateHighlightColor()
         self.updateAlpha()

--- a/plotgui.py
+++ b/plotgui.py
@@ -27,7 +27,8 @@ else:
         FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
 
 from plot_colors import rgb_normalize, invert_rgb
-from plotmodel import DomainDelegate, _NOT_FOUND, _VOID_REGION
+from plotmodel import DomainDelegate
+from plotmodel import _NOT_FOUND, _VOID_REGION, _MODEL_PROPERTIES
 
 class PlotImage(FigureCanvas):
 
@@ -163,7 +164,7 @@ class PlotImage(FigureCanvas):
         id, properties, domain, domain_kind = self.getIDinfo(event)
         if self.ax.contains_point((event.pos().x(), event.pos().y())):
 
-            if domain_kind.lower() in ('temperature', 'density'):
+            if domain_kind.lower() in _MODEL_PROPERTIES:
                 line_val = float(properties[domain_kind.lower()])
                 self.updateDataindicatorValue(line_val if line_val >= 0.0 else 0.0)
 
@@ -290,7 +291,7 @@ class PlotImage(FigureCanvas):
             self.menu.addAction(self.mw.undoAction)
             self.menu.addAction(self.mw.redoAction)
 
-            if cv.colorby not in ('temperature', 'density'):
+            if cv.colorby not in _MODEL_PROPERTIES:
                 self.menu.addSeparator()
                 bgColorAction = self.menu.addAction('Edit Background Color...')
                 bgColorAction.setToolTip('Edit background color')
@@ -402,7 +403,7 @@ class PlotImage(FigureCanvas):
 
     def updateDataindicatorVisibility(self):
         av = self.model.activeView
-        if self.data_indicator and av.colorby in ('temperature', 'density'):
+        if self.data_indicator and av.colorby in _MODEL_PROPERTIES:
             val = av.dataindicator_enabled[av.colorby]
             self.data_indicator.set_visible(val)
             self.draw()
@@ -820,15 +821,17 @@ class ColorDialog(QDialog):
             self.temperatureTab.colormapBox.setCurrentIndex(index)
 
     def updateColorMinMax(self):
-        minmax = self.model.activeView.user_minmax['density']
-        self.densityTab.minBox.setValue(minmax[0])
-        self.densityTab.maxBox.setValue(minmax[1])
         minmax = self.model.activeView.user_minmax['temperature']
         self.temperatureTab.minBox.setValue(minmax[0])
         self.temperatureTab.maxBox.setValue(minmax[1])
 
-        self.densityTab.minMaxCheckBox.setChecked(self.model.activeView.use_custom_minmax['density'])
+        minmax = self.model.activeView.user_minmax['density']
+        self.densityTab.minBox.setValue(minmax[0])
+        self.densityTab.maxBox.setValue(minmax[1])
+
         self.temperatureTab.minMaxCheckBox.setChecked(self.model.activeView.use_custom_minmax['temperature'])
+        self.densityTab.minMaxCheckBox.setChecked(self.model.activeView.use_custom_minmax['density'])
+
 
     def createPropertyTab(self, property_kind):
         propertyTab = QWidget()

--- a/plotgui.py
+++ b/plotgui.py
@@ -84,8 +84,8 @@ class PlotImage(FigureCanvas):
 
         cv = self.model.currentView
 
-        transform = self.ax.transAxes.inverted()
         # get the normalized axis coordinates from the event display units
+        transform = self.ax.transAxes.inverted()
         xPlotCoord, yPlotCoord = transform.transform((pos.x(), pos.y()))
         # flip the y-axis (its zero is in the upper left)
         yPlotCoord = 1 - yPlotCoord

--- a/plotgui.py
+++ b/plotgui.py
@@ -272,8 +272,10 @@ class PlotImage(FigureCanvas):
             colorAction.setDisabled(cv.highlighting)
             colorAction.setToolTip(f'Edit {domain_kind} color')
             colorAction.setStatusTip(f'Edit {domain_kind} color')
-            colorAction.triggered.connect(lambda:
-                                          self.mw.editDomainColor(domain_kind, id))
+            domain_color_connector = partial(self.mw.editDomainColor,
+                                             domain_kind,
+                                             id)
+            colorAction.triggered.connect(domain_color_connector)
 
             maskAction = self.menu.addAction(f'Mask {domain_kind}')
             maskAction.setCheckable(True)
@@ -281,8 +283,10 @@ class PlotImage(FigureCanvas):
             maskAction.setDisabled(not cv.masking)
             maskAction.setToolTip(f'Toggle {domain_kind} mask')
             maskAction.setStatusTip(f'Toggle {domain_kind} mask')
-            maskAction.triggered[bool].connect(lambda bool=bool:
-                                               self.mw.toggleDomainMask(bool, domain_kind, id))
+            mask_connector = partial(self.mw.toggleDomainMask,
+                                     kind=domain_kind,
+                                     id=id)
+            maskAction.toggled.connect(mask_connector)
 
             highlightAction = self.menu.addAction(f'Highlight {domain_kind}')
             highlightAction.setCheckable(True)
@@ -290,8 +294,10 @@ class PlotImage(FigureCanvas):
             highlightAction.setDisabled(not cv.highlighting)
             highlightAction.setToolTip(f'Toggle {domain_kind} highlight')
             highlightAction.setStatusTip(f'Toggle {domain_kind} highlight')
-            highlightAction.triggered[bool].connect(lambda bool=bool:
-                                                    self.mw.toggleDomainHighlight(bool, domain_kind, id))
+            highlight_connector = partial(self.mw.toggleDomainHighlight,
+                                          kind=domain_kind,
+                                          id=id)
+            highlightAction.toggled.connect(highlight_connector)
 
         else:
             self.menu.addAction(self.mw.undoAction)
@@ -302,7 +308,7 @@ class PlotImage(FigureCanvas):
                 bgColorAction = self.menu.addAction('Edit Background Color...')
                 bgColorAction.setToolTip('Edit background color')
                 bgColorAction.setStatusTip('Edit plot background color')
-                connector = lambda: self.mw.editBackgroundColor(apply=True)
+                connector = partial(self.mw.editBackgroundColor, apply=True)
                 bgColorAction.triggered.connect(connector)
 
         self.menu.addSeparator()
@@ -507,22 +513,25 @@ class OptionsDock(QDockWidget):
         self.xOrBox = QDoubleSpinBox()
         self.xOrBox.setDecimals(9)
         self.xOrBox.setRange(-99999, 99999)
-        self.xOrBox.valueChanged.connect(lambda value:
-                                         self.mw.editSingleOrigin(value, 0))
+        xbox_connector = partial(self.mw.editSingleOrigin,
+                                 dimension=0)
+        self.xOrBox.valueChanged.connect(xbox_connector)
 
         # Y Origin
         self.yOrBox = QDoubleSpinBox()
         self.yOrBox.setDecimals(9)
         self.yOrBox.setRange(-99999, 99999)
-        self.yOrBox.valueChanged.connect(lambda value:
-                                         self.mw.editSingleOrigin(value, 1))
+        ybox_connector = partial(self.mw.editSingleOrigin,
+                                 dimension=1)
+        self.yOrBox.valueChanged.connect(ybox_connector)
 
         # Z Origin
         self.zOrBox = QDoubleSpinBox()
         self.zOrBox.setDecimals(9)
         self.zOrBox.setRange(-99999, 99999)
-        self.zOrBox.valueChanged.connect(lambda value:
-                                         self.mw.editSingleOrigin(value, 2))
+        zbox_connector = partial(self.mw.editSingleOrigin,
+                                 dimension=2)
+        self.zOrBox.valueChanged.connect(zbox_connector)
 
         # Origin Form Layout
         self.orLayout = QFormLayout()
@@ -949,7 +958,6 @@ class ColorDialog(QDialog):
         self.updateSeed()
         self.updateBackgroundColor()
         self.updateColorBy()
-
         self.updateDomainTabs()
 
     def updateMasking(self):

--- a/plotgui.py
+++ b/plotgui.py
@@ -371,7 +371,7 @@ class PlotImage(FigureCanvas):
                 cmap_label = "Temperature (K)"
             else:
                 idx = 1
-                cmap_label = "Density (g/ccm)"
+                cmap_label = "Density (g/cc)"
 
             norm = SymLogNorm(1E-2) if cv.color_scale_log[cv.colorby] else None
             data = self.model.properties[:, :, idx]

--- a/plotgui.py
+++ b/plotgui.py
@@ -172,7 +172,7 @@ class PlotImage(FigureCanvas):
             if domain_kind.lower() in _MODEL_PROPERTIES:
                 line_val = float(properties[domain_kind.lower()])
                 line_val = max(line_val, 0.0)
-                self.updateDataindicatorValue(line_val)
+                self.updateDataIndicatorValue(line_val)
 
             if id == str(_VOID_REGION):
                 domainInfo = ("VOID")
@@ -188,7 +188,7 @@ class PlotImage(FigureCanvas):
                 domainInfo = ""
         else:
             domainInfo = ""
-            self.updateDataindicatorValue(0.0)
+            self.updateDataIndicatorValue(0.0)
 
         self.mw.statusBar().showMessage(f" {domainInfo}")
 
@@ -393,7 +393,7 @@ class PlotImage(FigureCanvas):
                                                 color='blue',
                                                 clip_on=True)
             self.colorbar.ax.add_line(self.data_indicator)
-            self.updateDataindicatorVisibility()
+            self.updateDataIndicatorVisibility()
             self.updateColorMinMax(cv.colorby)
 
         self.ax = self.figure.axes[0]
@@ -409,7 +409,7 @@ class PlotImage(FigureCanvas):
     def updateColorBarScale(self):
         self.setPixmap()
 
-    def updateDataindicatorValue(self, y_val):
+    def updateDataIndicatorValue(self, y_val):
         if self.data_indicator:
             data = self.data_indicator.get_data()
             self.data_indicator.set_data([data[0], [y_val, y_val]])
@@ -417,10 +417,10 @@ class PlotImage(FigureCanvas):
             self.data_indicator.set_c(dl_color)
             self.draw()
 
-    def updateDataindicatorVisibility(self):
+    def updateDataIndicatorVisibility(self):
         av = self.model.activeView
         if self.data_indicator and av.colorby in _MODEL_PROPERTIES:
-            val = av.dataindicator_enabled[av.colorby]
+            val = av.data_indicator_enabled[av.colorby]
             self.data_indicator.set_visible(val)
             self.draw()
 
@@ -821,10 +821,10 @@ class ColorDialog(QDialog):
 
         return domainTab
 
-    def updateDataindicatorVisibility(self):
+    def updateDataIndicatorVisibility(self):
         av = self.model.activeView
-        for key, val in av.dataindicator_enabled.items():
-            self.tabs[key].dataindicatorCheckBox.setChecked(val)
+        for key, val in av.data_indicator_enabled.items():
+            self.tabs[key].dataIndicatorCheckBox.setChecked(val)
 
     def updateColorMaps(self):
         cmaps = self.model.activeView.colormaps
@@ -882,11 +882,11 @@ class ColorDialog(QDialog):
 
         propertyTab.colormapBox.currentTextChanged[str].connect(connector)
 
-        propertyTab.dataindicatorCheckBox = QCheckBox()
-        propertyTab.dataindicatorCheckBox.setCheckable(True)
+        propertyTab.dataIndicatorCheckBox = QCheckBox()
+        propertyTab.dataIndicatorCheckBox.setCheckable(True)
         connector4 = partial(self.mw.toggleDataIndicatorCheckBox,
                              property=property_kind)
-        propertyTab.dataindicatorCheckBox.stateChanged.connect(connector4)
+        propertyTab.dataIndicatorCheckBox.stateChanged.connect(connector4)
 
         propertyTab.colorBarScaleCheckBox = QCheckBox()
         propertyTab.colorBarScaleCheckBox.setCheckable(True)
@@ -902,7 +902,7 @@ class ColorDialog(QDialog):
         formLayout.addRow('Colormap:', propertyTab.colormapBox)
 
         formLayout.addRow('Custom Min/Max', propertyTab.minMaxCheckBox)
-        formLayout.addRow('Data Indicator', propertyTab.dataindicatorCheckBox)
+        formLayout.addRow('Data Indicator', propertyTab.dataIndicatorCheckBox)
         formLayout.addRow('Log Scale', propertyTab.colorBarScaleCheckBox)
         formLayout.addRow(HorizontalLine())
         formLayout.addRow('Max: ', propertyTab.maxBox)
@@ -934,7 +934,7 @@ class ColorDialog(QDialog):
         self.updateColorMaps()
         self.updateColorMinMax()
         self.updateColorBarScale()
-        self.updateDataindicatorVisibility()
+        self.updateDataIndicatorVisibility()
         self.updateHighlighting()
         self.updateHighlightColor()
         self.updateAlpha()

--- a/plotgui.py
+++ b/plotgui.py
@@ -126,9 +126,9 @@ class PlotImage(FigureCanvas):
         # check that the position is in the axes view
         if 0 <= yPos < self.model.currentView.v_res \
            and 0 <= xPos and xPos < self.model.currentView.h_res:
-            id = f"{self.model.ids[yPos][xPos]}"
-            temp = f"{self.model.properties[yPos][xPos][0]:g}"
-            density = f"{self.model.properties[yPos][xPos][1]:g}"
+            id = "{}".format(self.model.ids[yPos][xPos])
+            temp = "{:g}".format(self.model.properties[yPos][xPos][0])
+            density = "{:g}".format(self.model.properties[yPos][xPos][1])
         else:
             id = str(_NOT_FOUND)
             density = str(_NOT_FOUND)
@@ -172,24 +172,34 @@ class PlotImage(FigureCanvas):
                 line_val = float(properties[domain_kind.lower()])
                 line_val = max(line_val, 0.0)
                 self.updateDataIndicatorValue(line_val)
+                domain_kind = 'Material'
+
+            temperature = properties['temperature']
+            density = properties['density']
 
             if id == str(_VOID_REGION):
                 domainInfo = ("VOID")
             elif id != str(_NOT_FOUND) and domain[id].name:
-                domainInfo = (f"{domain_kind} {id}: \"{domain[id].name}\"\t "
-                              f"Density: {properties['density']} g/cm3\t"
-                              f"Temperature: {properties['temperature']} K")
+                domainInfo = ("{} {}: \"{}\"\t Density: {} g/cc\t"
+                              "Temperature: {} K".format(domain_kind,
+                                                         id,
+                                                         domain[id].name,
+                                                         density,
+                                                         temperature))
             elif id != str(_NOT_FOUND):
-                domainInfo = (f"{domain_kind} {id}\t"
-                              f"Density: {properties['density']} g/cm3\t"
-                              f"Temperature: {properties['temperature']} K")
+                domainInfo = ("{} {}\t Density: {} g/cc\t"
+                              "Temperature: {} K".format(domain_kind,
+                                                         id,
+                                                         domain[id].name,
+                                                         density,
+                                                         temperature))
             else:
                 domainInfo = ""
         else:
             domainInfo = ""
             self.updateDataIndicatorValue(0.0)
 
-        self.mw.statusBar().showMessage(f" {domainInfo}")
+        self.mw.statusBar().showMessage(" " + domainInfo)
 
         # Update rubber band and values if mouse button held down
         if event.buttons() == QtCore.Qt.LeftButton:
@@ -244,8 +254,8 @@ class PlotImage(FigureCanvas):
 
         self.menu.clear()
 
-        self.mw.undoAction.setText(f'&Undo ({len(self.model.previousViews)})')
-        self.mw.redoAction.setText(f'&Redo ({len(self.model.subsequentViews)})')
+        self.mw.undoAction.setText('&Undo ({})'.format(len(self.model.previousViews)))
+        self.mw.redoAction.setText('&Redo ({})'.format(len(self.model.subsequentViews)))
 
         id, properties, domain, domain_kind = self.getIDinfo(event)
 
@@ -260,7 +270,7 @@ class PlotImage(FigureCanvas):
         if id != str(_NOT_FOUND) and cv.colorby not in _MODEL_PROPERTIES:
 
             # Domain ID
-            domainID = self.menu.addAction(f"{domain_kind} {id}")
+            domainID = self.menu.addAction("{} {}".format(domain_kind, id))
             domainID.setDisabled(True)
 
             # Domain Name (if any)
@@ -268,32 +278,32 @@ class PlotImage(FigureCanvas):
                 domainName = self.menu.addAction(domain[id].name)
                 domainName.setDisabled(True)
 
-            colorAction = self.menu.addAction(f'Edit {domain_kind} Color...')
+            colorAction = self.menu.addAction('Edit {} Color...'.format(domain_kind))
             colorAction.setDisabled(cv.highlighting)
-            colorAction.setToolTip(f'Edit {domain_kind} color')
-            colorAction.setStatusTip(f'Edit {domain_kind} color')
+            colorAction.setToolTip('Edit {} color'.format(domain_kind))
+            colorAction.setStatusTip('Edit {} color'.format(domain_kind))
             domain_color_connector = partial(self.mw.editDomainColor,
                                              domain_kind,
                                              id)
             colorAction.triggered.connect(domain_color_connector)
 
-            maskAction = self.menu.addAction(f'Mask {domain_kind}')
+            maskAction = self.menu.addAction('Mask {}'.format(domain_kind))
             maskAction.setCheckable(True)
             maskAction.setChecked(domain[id].masked)
             maskAction.setDisabled(not cv.masking)
-            maskAction.setToolTip(f'Toggle {domain_kind} mask')
-            maskAction.setStatusTip(f'Toggle {domain_kind} mask')
+            maskAction.setToolTip('Toggle {} mask'.format(domain_kind))
+            maskAction.setStatusTip('Toggle {} mask'.format(domain_kind))
             mask_connector = partial(self.mw.toggleDomainMask,
                                      kind=domain_kind,
                                      id=id)
             maskAction.toggled.connect(mask_connector)
 
-            highlightAction = self.menu.addAction(f'Highlight {domain_kind}')
+            highlightAction = self.menu.addAction('Highlight {}'.format(domain_kind))
             highlightAction.setCheckable(True)
             highlightAction.setChecked(domain[id].highlighted)
             highlightAction.setDisabled(not cv.highlighting)
-            highlightAction.setToolTip(f'Toggle {domain_kind} highlight')
-            highlightAction.setStatusTip(f'Toggle {domain_kind} highlight')
+            highlightAction.setToolTip('Toggle {} highlight'.format(domain_kind))
+            highlightAction.setStatusTip('Toggle {} highlight'.format(domain_kind))
             highlight_connector = partial(self.mw.toggleDomainHighlight,
                                           kind=domain_kind,
                                           id=id)

--- a/plotgui.py
+++ b/plotgui.py
@@ -242,13 +242,15 @@ class PlotImage(FigureCanvas):
 
         id, properties, domain, domain_kind = self.getIDinfo(event)
 
+        cv = self.model.currentView
+
         # always provide undo option
         self.menu.addSeparator()
         self.menu.addAction(self.mw.undoAction)
         self.menu.addAction(self.mw.redoAction)
         self.menu.addSeparator()
 
-        if id != str(_NOT_FOUND) and domain_kind.lower() not in ('density', 'temperature'):
+        if id != str(_NOT_FOUND) and cv.colorby not in ('density', 'temperature'):
 
             # Domain ID
             domainID = self.menu.addAction(f"{domain_kind} {id}")
@@ -260,7 +262,7 @@ class PlotImage(FigureCanvas):
                 domainName.setDisabled(True)
 
             colorAction = self.menu.addAction(f'Edit {domain_kind} Color...')
-            colorAction.setDisabled(self.model.currentView.highlighting)
+            colorAction.setDisabled(cv.highlighting)
             colorAction.setToolTip(f'Edit {domain_kind} color')
             colorAction.setStatusTip(f'Edit {domain_kind} color')
             colorAction.triggered.connect(lambda :
@@ -269,7 +271,7 @@ class PlotImage(FigureCanvas):
             maskAction = self.menu.addAction(f'Mask {domain_kind}')
             maskAction.setCheckable(True)
             maskAction.setChecked(domain[id].masked)
-            maskAction.setDisabled(not self.model.currentView.masking)
+            maskAction.setDisabled(not cv.masking)
             maskAction.setToolTip(f'Toggle {domain_kind} mask')
             maskAction.setStatusTip(f'Toggle {domain_kind} mask')
             maskAction.triggered[bool].connect(lambda bool=bool:
@@ -278,7 +280,7 @@ class PlotImage(FigureCanvas):
             highlightAction = self.menu.addAction(f'Highlight {domain_kind}')
             highlightAction.setCheckable(True)
             highlightAction.setChecked(domain[id].highlighted)
-            highlightAction.setDisabled(not self.model.currentView.highlighting)
+            highlightAction.setDisabled(not cv.highlighting)
             highlightAction.setToolTip(f'Toggle {domain_kind} highlight')
             highlightAction.setStatusTip(f'Toggle {domain_kind} highlight')
             highlightAction.triggered[bool].connect(lambda bool=bool:
@@ -287,12 +289,14 @@ class PlotImage(FigureCanvas):
         else:
             self.menu.addAction(self.mw.undoAction)
             self.menu.addAction(self.mw.redoAction)
-            self.menu.addSeparator()
-            bgColorAction = self.menu.addAction('Edit Background Color...')
-            bgColorAction.setToolTip('Edit background color')
-            bgColorAction.setStatusTip('Edit plot background color')
-            bgColorAction.triggered.connect(lambda :
-                self.mw.editBackgroundColor(apply=True))
+
+            if cv.colorby not in ('temperature', 'density'):
+                self.menu.addSeparator()
+                bgColorAction = self.menu.addAction('Edit Background Color...')
+                bgColorAction.setToolTip('Edit background color')
+                bgColorAction.setStatusTip('Edit plot background color')
+                connector = lambda : self.mw.editBackgroundColor(apply=True)
+                bgColorAction.triggered.connect(connector)
 
         self.menu.addSeparator()
         self.menu.addAction(self.mw.saveImageAction)
@@ -308,8 +312,8 @@ class PlotImage(FigureCanvas):
             self.menu.addSeparator()
         self.menu.addAction(self.mw.dockAction)
 
-        self.mw.maskingAction.setChecked(self.model.currentView.masking)
-        self.mw.highlightingAct.setChecked(self.model.currentView.highlighting)
+        self.mw.maskingAction.setChecked(cv.masking)
+        self.mw.highlightingAct.setChecked(cv.highlighting)
 
         if self.mw.dock.isVisible():
             self.mw.dockAction.setText('Hide &Dock')

--- a/plotgui.py
+++ b/plotgui.py
@@ -15,6 +15,7 @@ from matplotlib.figure import Figure
 from matplotlib import image as mpimage
 from matplotlib import lines as mlines
 from matplotlib import cm as mcolormaps
+from matplotlib.colors import LogNorm
 
 import matplotlib.pyplot as plt
 
@@ -353,7 +354,7 @@ class PlotImage(FigureCanvas):
                 clim = cv.colorbar_minmax[cv.colorby]
                 cmap_label = "Density (g/ccm)"
 
-            self.image = self.figure.subplots().imshow(self.model.properties[:,:,idx],
+            self.image = self.figure.subplots().matshow(self.model.properties[:,:,idx],
                                               cmap=cmap,
                                               extent=data_bounds,
                                               alpha=cv.plotAlpha)
@@ -375,6 +376,8 @@ class PlotImage(FigureCanvas):
                                            color='blue',
                                            clip_on=True)
             self.colorbar.ax.add_line(self.data_line)
+
+            self.updateColorMinMax(cv.colorby)
 
         self.ax = self.figure.axes[0]
         self.ax.margins(0.0, 0.0)
@@ -400,12 +403,13 @@ class PlotImage(FigureCanvas):
             self.colorbar.draw_all()
             self.draw()
 
-    def updateColorMinMax(self, min_val, max_val, property_type):
+    def updateColorMinMax(self, property_type):
         av = self.model.activeView
         if self.colorbar and property_type == av.colorby:
             self.colorbar.set_clim(*av.colorbar_minmax[property_type])
             self.colorbar.draw_all()
             self.draw()
+
 
 class OptionsDock(QDockWidget):
     def __init__(self, model, FM, parent=None):
@@ -814,9 +818,9 @@ class ColorDialog(QDialog):
         propertyTab.minBox = QDoubleSpinBox(self)
         propertyTab.maxBox = QDoubleSpinBox(self)
 
-        connector = partial(self.mw.editColorBarMinMax, max_val=propertyTab.maxBox.value(), property_type=property_kind)
+        connector = partial(self.mw.editColorBarMin, property_type=property_kind)
         propertyTab.minBox.valueChanged.connect(connector)
-        connector = partial(self.mw.editColorBarMinMax, min_val=propertyTab.minBox.value(), property_type=property_kind)
+        connector = partial(self.mw.editColorBarMax, property_type=property_kind)
         propertyTab.maxBox.valueChanged.connect(connector)
 
         propertyTab.colormapBox = QComboBox(self)

--- a/plotgui.py
+++ b/plotgui.py
@@ -381,10 +381,10 @@ class PlotImage(FigureCanvas):
             self.colorbar = self.figure.colorbar(self.image,
                                                  cax=cmap_ax,
                                                  anchor=(1.0, 0.0))
-            self.colorbar.ax.set_ylabel(cmap_label,
-                                        rotation=-90,
-                                        va='bottom',
-                                        ha='right')
+            self.colorbar.set_label(cmap_label,
+                                    rotation=-90,
+                                    va='bottom',
+                                    ha='right')
             # draw line on colorbar
             dl = self.colorbar.ax.dataLim.get_points()
             self.data_indicator = mlines.Line2D(dl[:][0],
@@ -410,8 +410,17 @@ class PlotImage(FigureCanvas):
         self.setPixmap()
 
     def updateDataIndicatorValue(self, y_val):
+        av = self.model.currentView
         if self.data_indicator:
             data = self.data_indicator.get_data()
+            if av.color_scale_log[av.colorby]:
+                print(y_val)
+                trans = self.colorbar.ax.transData + \
+                        self.colorbar.ax.transAxes.inverted()
+                print(y_val)
+                _, y_val = trans.transform((0.0, y_val))
+                y_val  = 1 - y_val
+                print(y_val)
             self.data_indicator.set_data([data[0], [y_val, y_val]])
             dl_color = invert_rgb(self.colorbar.get_cmap()(y_val), True)
             self.data_indicator.set_c(dl_color)

--- a/plotgui.py
+++ b/plotgui.py
@@ -26,7 +26,7 @@ else:
     from matplotlib.backends.backend_qt5agg import (
         FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
 
-from plot_colors import rgb_normalize
+from plot_colors import rgb_normalize, invert_rgb
 from plotmodel import DomainDelegate, _NOT_FOUND, _VOID_REGION
 
 class PlotImage(FigureCanvas):
@@ -394,6 +394,8 @@ class PlotImage(FigureCanvas):
         if self.data_line:
             data = self.data_line.get_data()
             self.data_line.set_data([data[0], [y_val, y_val]])
+            dl_color = invert_rgb(self.colorbar.get_cmap()(y_val), True)
+            self.data_line.set_c(dl_color)
             self.draw()
 
     def updateDataLineVisibility(self):

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -383,8 +383,12 @@ class DomainView():
         self.highlighted = highlighted
 
     def __repr__(self):
-        return (f"id: {self.id} \nname: {self.name} \ncolor: {self.color} \
-                \nmask: {self.masked} \nhighlight: {self.highlighted}\n\n")
+        return ("id: {} \nname: {} \ncolor: {} \
+                \nmask: {} \nhighlight: {}\n\n".format(self.id,
+                                                       self.name,
+                                                       self.color,
+                                                       self.masked,
+                                                       self.highlight))
 
     def __eq__(self, other):
         if isinstance(other, DomainView):

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -122,7 +122,7 @@ class PlotModel():
 
         cv = self.currentView = copy.deepcopy(self.activeView)
         ids = capi_plot.id_map(cv)
-        self.props = capi_plot.property_map(cv)
+        props = capi_plot.property_map(cv)
         # empty image data
         image = np.ones((cv.v_res, cv.h_res, 3), dtype = int)
 
@@ -164,6 +164,8 @@ class PlotModel():
 
         # set model image
         self.image = image
+        # set model properties
+        self.properties = props
 
     def undo(self):
         """ Revert to previous PlotView instance. Re-generate plot image """
@@ -215,7 +217,7 @@ class PlotView(_PlotBase):
         prevent image stretching/warping
     basis : {'xy', 'xz', 'yz'}
         The basis directions for the plot
-    colorby : {'cell', 'material'}
+    colorby : {'cell', 'material', 'temperature', 'density'}
         Indication of whether the plot should be colored by cell or material
     masking : bool
         Indication of whether cell/material masking is active

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -289,7 +289,7 @@ class PlotView(_PlotBase):
         self.data_minmax = {prop: (0.0, 0.0) for prop in _MODEL_PROPERTIES}
         self.user_minmax = {prop: (0.0, 0.0) for prop in _MODEL_PROPERTIES}
         self.use_custom_minmax = {prop: False for prop in _MODEL_PROPERTIES}
-        self.dataindicator_enabled = {prop: False for prop in _MODEL_PROPERTIES}
+        self.data_indicator_enabled = {prop: False for prop in _MODEL_PROPERTIES}
         self.color_scale_log = {prop: False for prop in _MODEL_PROPERTIES}
 
         self.cells = self.getDomains('geometry.xml', 'cell')

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -21,6 +21,7 @@ __VERSION__ = "0.1.0"
 _VOID_REGION = -1
 _NOT_FOUND = -2
 
+_MODEL_PROPERTIES = ('temperature', 'density')
 
 class PlotModel():
     """ Geometry and plot settings for OpenMC Plot Explorer model

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -167,6 +167,9 @@ class PlotModel():
         # set model properties
         self.properties = props
 
+        self.properties[self.properties < 0.0] = 0.0
+
+
     def undo(self):
         """ Revert to previous PlotView instance. Re-generate plot image """
 

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -291,6 +291,9 @@ class PlotView(_PlotBase):
         self.log_scale = { 'temperature' : False,
                            'density' : False }
 
+        self.dataline_enabled = { 'temperature' : False,
+                                  'density' : False }
+
         self.cells = self.getDomains('geometry.xml', 'cell')
         self.materials = self.getDomains('materials.xml', 'material')
 

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -169,11 +169,10 @@ class PlotModel():
 
         self.properties[self.properties < 0.0] = 0.0
 
-        cv.colorbar_minmax['temperature'] = (np.min(self.properties[:,:,0]),
-                                             np.max(self.properties[:,:,0]))
-        cv.colorbar_minmax['density'] = (np.min(self.properties[:,:,1]),
-                                         np.max(self.properties[:,:,1]))
-
+        self.activeView.colorbar_minmax['temperature'] = (np.min(self.properties[:,:,0]),
+                                                          np.max(self.properties[:,:,0]))
+        self.activeView.colorbar_minmax['density'] = (np.min(self.properties[:,:,1]),
+                                                      np.max(self.properties[:,:,1]))
 
     def undo(self):
         """ Revert to previous PlotView instance. Re-generate plot image """
@@ -282,6 +281,9 @@ class PlotView(_PlotBase):
 
         self.colorbar_minmax = { 'temperature' : (0.0, 0.0),
                                  'density'     : (0.0, 0.0) }
+
+        self.log_scale = { 'temperature' : False,
+                           'density' : False }
 
         self.cells = self.getDomains('geometry.xml', 'cell')
         self.materials = self.getDomains('materials.xml', 'material')

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -171,7 +171,7 @@ class PlotModel():
         # set model properties
         self.properties = props
 
-        self.properties[self.properties < 0.0] = 0.0
+        self.properties[self.properties < 0.0] = np.nan
 
         minmax = {}
         for prop in _MODEL_PROPERTIES:

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -291,8 +291,8 @@ class PlotView(_PlotBase):
         self.log_scale = { 'temperature' : False,
                            'density' : False }
 
-        self.dataline_enabled = { 'temperature' : False,
-                                  'density' : False }
+        self.dataindicator_enabled = { 'temperature' : False,
+                                       'density' : False }
 
         self.cells = self.getDomains('geometry.xml', 'cell')
         self.materials = self.getDomains('materials.xml', 'material')

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -280,20 +280,12 @@ class PlotView(_PlotBase):
         self.colormaps = { 'temperature' : 'Oranges',
                            'density' : 'Greys' }
 
-        self.data_minmax = { 'temperature' : (0.0, 0.0),
-                             'density'     : (0.0, 0.0) }
-
-        self.user_minmax = { 'temperature' : (0.0, 0.0),
-                             'density'     : (0.0, 0.0) }
-
-        self.use_custom_minmax = {'temperature' : False,
-                                  'density' : False}
-
-        self.log_scale = { 'temperature' : False,
-                           'density' : False }
-
-        self.dataindicator_enabled = { 'temperature' : False,
-                                       'density' : False }
+        # set defaults for color dialog
+        self.data_minmax = {prop: (0.0, 0.0) for prop in _MODEL_PROPERTIES}
+        self.user_minmax =  {prop: (0.0, 0.0) for prop in _MODEL_PROPERTIES}
+        self.use_custom_minmax = {prop: False for prop in _MODEL_PROPERTIES}
+        self.dataindicator_enabled = {prop: False for prop in _MODEL_PROPERTIES}
+        self.color_scale_log = {prop: False for prop in _MODEL_PROPERTIES}
 
         self.cells = self.getDomains('geometry.xml', 'cell')
         self.materials = self.getDomains('materials.xml', 'material')

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -169,9 +169,9 @@ class PlotModel():
 
         self.properties[self.properties < 0.0] = 0.0
 
-        self.activeView.colorbar_minmax['temperature'] = (np.min(self.properties[:,:,0]),
+        self.activeView.data_minmax['temperature'] = (np.min(self.properties[:,:,0]),
                                                           np.max(self.properties[:,:,0]))
-        self.activeView.colorbar_minmax['density'] = (np.min(self.properties[:,:,1]),
+        self.activeView.data_minmax['density'] = (np.min(self.properties[:,:,1]),
                                                       np.max(self.properties[:,:,1]))
 
     def undo(self):
@@ -279,8 +279,14 @@ class PlotView(_PlotBase):
         self.colormaps = { 'temperature' : 'Oranges',
                            'density' : 'Greys' }
 
-        self.colorbar_minmax = { 'temperature' : (0.0, 0.0),
-                                 'density'     : (0.0, 0.0) }
+        self.data_minmax = { 'temperature' : (0.0, 0.0),
+                             'density'     : (0.0, 0.0) }
+
+        self.user_minmax = { 'temperature' : (0.0, 0.0),
+                             'density'     : (0.0, 0.0) }
+
+        self.use_custom_minmax = {'temperature' : False,
+                                  'density' : False}
 
         self.log_scale = { 'temperature' : False,
                            'density' : False }
@@ -337,6 +343,15 @@ class PlotView(_PlotBase):
                                           False)
 
         return domains
+
+    def getDataLimits(self):
+        return self.data_minmax
+
+    def getColorLimits(self, property):
+        if self.use_custom_minmax[property]:
+            return self.user_minmax[property]
+        else:
+            return self.data_minmax[property]
 
 class DomainView():
     """ Represents view settings for OpenMC cell or material.

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -169,6 +169,11 @@ class PlotModel():
 
         self.properties[self.properties < 0.0] = 0.0
 
+        cv.colorbar_minmax['temperature'] = (np.min(self.properties[:,:,0]),
+                                             np.max(self.properties[:,:,0]))
+        cv.colorbar_minmax['density'] = (np.min(self.properties[:,:,1]),
+                                         np.max(self.properties[:,:,1]))
+
 
     def undo(self):
         """ Revert to previous PlotView instance. Re-generate plot image """
@@ -274,6 +279,9 @@ class PlotView(_PlotBase):
 
         self.colormaps = { 'temperature' : 'Oranges',
                            'density' : 'Greys' }
+
+        self.colorbar_minmax = { 'temperature' : (0.0, 0.0),
+                                 'density'     : (0.0, 0.0) }
 
         self.cells = self.getDomains('geometry.xml', 'cell')
         self.materials = self.getDomains('materials.xml', 'material')

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -272,6 +272,9 @@ class PlotView(_PlotBase):
 
         self.plotAlpha = 1.0
 
+        self.colormaps = { 'temperature' : 'Oranges',
+                           'density' : 'Greys' }
+
         self.cells = self.getDomains('geometry.xml', 'cell')
         self.materials = self.getDomains('materials.xml', 'material')
 

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -23,8 +23,7 @@ _VOID_REGION = -1
 _NOT_FOUND = -2
 
 _MODEL_PROPERTIES = ('temperature', 'density')
-_PROPERTY_INDICES = {'temperature': 0,
-                     'density': 1}
+_PROPERTY_INDICES = {'temperature': 0, 'density': 1}
 
 
 class PlotModel():


### PR DESCRIPTION
This PR adds temperature and density the plotter.

Model properties can be displayed in a similar fashion to materials and cells. These plots allow for customization of colors in the following ways in the ColorDiaglog window:

  - colormap seclection
  - user-specified minimum/maximum
  - linear/log scale color space
  - a data indicator which updates in the colorbar based on mouse position

Property data is also shown in the status bar at the bottom of the window based on mouse position.

These viewing types have been fully integrated into the window, dock, and context menus.

Settings for the property views are now saved along with the `.pltvw` files and will be restored when that view is reloaded into the GUI.