### PR TITLE
Various Fixes

### DIFF
--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -14,7 +14,8 @@ import openmc
 from PySide2 import QtCore, QtGui
 from PySide2.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
                                QScrollArea, QMenu, QAction, QFileDialog,
-                               QColorDialog, QInputDialog, QSplashScreen, QWidget, QGestureEvent)
+                               QColorDialog, QInputDialog, QSplashScreen,
+                               QWidget, QGestureEvent)
 
 from plotmodel import PlotModel, DomainTableModel
 from plotgui import PlotImage, ColorDialog, OptionsDock
@@ -49,8 +50,6 @@ class MainWindow(QMainWindow):
 
         # connect pinch gesture (OSX)
         self.grabGesture(QtCore.Qt.PinchGesture)
-
-
 
         # Create plot image
         self.plotIm = PlotImage(self.model, self.frame, self)
@@ -89,6 +88,7 @@ class MainWindow(QMainWindow):
             QtCore.QTimer.singleShot(0, self.showCurrentView)
 
     def event(self, event):
+        # use pinch event to update zoom
         if isinstance(event, QGestureEvent):
             pinch = event.gesture(QtCore.Qt.PinchGesture)
             self.editZoom(self.zoom * pinch.scaleFactor())
@@ -385,7 +385,6 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(message, 5000)
 
         return super().event(event)
-
 
     def applyChanges(self):
         if self.model.activeView != self.model.currentView:
@@ -793,7 +792,6 @@ class MainWindow(QMainWindow):
         self.adjustWindow()
 
     def resizeEvent(self, event):
-        z = self.zoom / 101.
         self.plotIm._resize()
         self.updateScale()
 

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -775,9 +775,13 @@ class MainWindow(QMainWindow):
         self.adjustWindow()
 
     def resizeEvent(self, event):
-        if self.pixmap:
-            self.adjustWindow()
-            self.updateScale()
+        z = self.zoom / 101.
+        self.plotIm.resize(self.frame.width() * z,
+                           self.frame.height() * z)
+        self.updateScale()
+        # if hasattr(self.model, 'image') and self.model.image is not None:
+        #     self.adjustWindow()
+        #     self.updateScale()
 
     def closeEvent(self, event):
         settings = QtCore.QSettings()

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -835,7 +835,7 @@ if __name__ == '__main__':
     FM = QtGui.QFontMetricsF(app.font())
     mainWindow = MainWindow()
     # connect splashscreen to main window, close when main window opens
-    splash.finish(mainWindow)
     mainWindow.loadGui()
     mainWindow.show()
+    splash.close()
     sys.exit(app.exec_())

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -793,6 +793,7 @@ class MainWindow(QMainWindow):
 
     def resizeEvent(self, event):
         self.plotIm._resize()
+        self.adjustWindow()
         self.updateScale()
 
     def closeEvent(self, event):

--- a/plotgui.py
+++ b/plotgui.py
@@ -403,7 +403,7 @@ class PlotImage(FigureCanvas):
                                                         norm=norm,
                                                         extent=data_bounds,
                                                         alpha=cv.plotAlpha)
-            cmap_ax = self.figure.add_axes([0.9, 0.1, 0.03, 0.8])
+            cmap_ax = self.figure.add_axes()
 
             # add colorbar
             self.colorbar = self.figure.colorbar(self.image,

--- a/plotgui.py
+++ b/plotgui.py
@@ -236,7 +236,6 @@ class PlotImage(FigureCanvas):
             self.mw.editWidth(width)
             self.mw.editHeight(height)
 
-        self.draw()
 
     def mouseReleaseEvent(self, event):
 
@@ -256,7 +255,6 @@ class PlotImage(FigureCanvas):
             if 24 < self.mw.zoom + numDegrees < 5001:
                 self.mw.editZoom(self.mw.zoom + numDegrees)
 
-        self.draw()
 
     def contextMenuEvent(self, event):
 

--- a/plotgui.py
+++ b/plotgui.py
@@ -82,14 +82,15 @@ class PlotImage(FigureCanvas):
         FigureCanvas.mousePressEvent(self, event)
 
     def getPlotCoords(self, pos):
-
+        print("FigCanvas coords:", self.mouseEventCoords(pos))
+        print("Event coords:", (pos.x(), pos.y()))
+        x, y = self.mouseEventCoords(pos)
         cv = self.model.currentView
 
         # get the normalized axis coordinates from the event display units
         transform = self.ax.transAxes.inverted()
-        xPlotCoord, yPlotCoord = transform.transform((pos.x(), pos.y()))
+        xPlotCoord, yPlotCoord = transform.transform((x, y))
         # flip the y-axis (its zero is in the upper left)
-        yPlotCoord = 1 - yPlotCoord
 
         # scale axes using the plot extents
         xPlotCoord = self.ax.dataLim.x0 + xPlotCoord * self.ax.dataLim.width
@@ -105,8 +106,8 @@ class PlotImage(FigureCanvas):
         return (xPlotCoord, yPlotCoord)
 
     def printPos(self, event):
-        print(event.x, event.y)
-        print(event.xdata, event.ydata)
+        print("MPL Event Disp Coords:", (event.x, event.y))
+        print("True Coords:", (event.xdata, event.ydata))
 
     def getIDinfo(self, event):
 

--- a/plotgui.py
+++ b/plotgui.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-import sys
 
 from plot_colors import rgb_normalize, invert_rgb
 from plotmodel import DomainDelegate
@@ -79,11 +78,8 @@ class PlotImage(FigureCanvas):
         self.rubber_band.setGeometry(QtCore.QRect(self.band_origin,
                                                   QtCore.QSize()))
 
-#        FigureCanvas.mousePressEvent(self, event)
-
     def getPlotCoords(self, pos):
         x, y = self.mouseEventCoords(pos)
-        cv = self.model.currentView
 
         # get the normalized axis coordinates from the event display units
         transform = self.ax.transAxes.inverted()
@@ -251,7 +247,6 @@ class PlotImage(FigureCanvas):
             self.mw.editWidth(width)
             self.mw.editHeight(height)
 
-
     def mouseReleaseEvent(self, event):
 
         if self.rubber_band.isVisible():
@@ -260,8 +255,6 @@ class PlotImage(FigureCanvas):
         else:
             self.mw.revertDockControls()
 
-
-
     def wheelEvent(self, event):
 
         if event.delta() and event.modifiers() == QtCore.Qt.ShiftModifier:
@@ -269,7 +262,6 @@ class PlotImage(FigureCanvas):
 
             if 24 < self.mw.zoom + numDegrees < 5001:
                 self.mw.editZoom(self.mw.zoom + numDegrees)
-
 
     def contextMenuEvent(self, event):
 
@@ -291,13 +283,10 @@ class PlotImage(FigureCanvas):
         if id != str(_NOT_FOUND) and cv.colorby not in _MODEL_PROPERTIES:
 
             # Domain ID
-            domainID = self.menu.addAction("{} {}".format(domain_kind, id))
-            domainID.setDisabled(True)
-
-            # Domain Name (if any)
             if domain[id].name:
-                domainName = self.menu.addAction(domain[id].name)
-                domainName.setDisabled(True)
+                domainID = self.menu.addAction("{} {}: \"{}\"".format(domain_kind, id, domain[id].name))
+            else:
+                domainID = self.menu.addAction("{} {}".format(domain_kind, id))
 
             colorAction = self.menu.addAction('Edit {} Color...'.format(domain_kind))
             colorAction.setDisabled(cv.highlighting)

--- a/plotgui.py
+++ b/plotgui.py
@@ -288,6 +288,8 @@ class PlotImage(FigureCanvas):
             else:
                 domainID = self.menu.addAction("{} {}".format(domain_kind, id))
 
+            self.menu.addSeparator()
+
             colorAction = self.menu.addAction('Edit {} Color...'.format(domain_kind))
             colorAction.setDisabled(cv.highlighting)
             colorAction.setToolTip('Edit {} color'.format(domain_kind))

--- a/plotgui.py
+++ b/plotgui.py
@@ -38,7 +38,7 @@ class PlotImage(FigureCanvas):
     def __init__(self, model, parent, main):
 
         self.figure = Figure(dpi=main.logicalDpiX())
-        super(FigureCanvas, self).__init__(self.figure)
+        super().__init__(self.figure)
 
         FigureCanvas.setSizePolicy(self,
                                    QSizePolicy.Expanding,

--- a/plotgui.py
+++ b/plotgui.py
@@ -82,8 +82,6 @@ class PlotImage(FigureCanvas):
         FigureCanvas.mousePressEvent(self, event)
 
     def getPlotCoords(self, pos):
-        print("FigCanvas coords:", self.mouseEventCoords(pos))
-        print("Event coords:", (pos.x(), pos.y()))
         x, y = self.mouseEventCoords(pos)
         cv = self.model.currentView
 
@@ -105,13 +103,11 @@ class PlotImage(FigureCanvas):
 
         return (xPlotCoord, yPlotCoord)
 
-    def printPos(self, event):
-        print("MPL Event Disp Coords:", (event.x, event.y))
-        print("True Coords:", (event.xdata, event.ydata))
-
     def getIDinfo(self, event):
 
         cv = self.model.currentView
+
+        x, y = self.mouseEventCoords(event.pos())
 
         # get origin in axes coordinates
         x0, y0 = self.ax.transAxes.transform((0.0, 0.0))
@@ -126,8 +122,9 @@ class PlotImage(FigureCanvas):
 
         # use factor to get proper x,y position in pixels
         factor = (width/cv.h_res, height/cv.v_res)
-        xPos = int((event.pos().x()-x0 + 0.01) / factor[0])
-        yPos = int((event.pos().y()-y0 + 0.01) / factor[1])
+        xPos = int((x - x0 + 0.01) / factor[0])
+        # flip y-axis
+        yPos = cv.v_res - int((y - y0 + 0.01) / factor[1])
 
         # check that the position is in the axes view
         if 0 <= yPos < self.model.currentView.v_res \
@@ -196,7 +193,6 @@ class PlotImage(FigureCanvas):
                 domainInfo = ("{} {}\t Density: {} g/cc\t"
                               "Temperature: {} K".format(domain_kind,
                                                          id,
-                                                         domain[id].name,
                                                          density,
                                                          temperature))
             else:
@@ -357,8 +353,6 @@ class PlotImage(FigureCanvas):
 
         # clear out figure
         self.figure.clear()
-        self.figure.canvas.mpl_connect('motion_notify_event', self.printPos)
-        self.figure.canvas.mpl_connect('button_press_event', self.printPos)
 
         cv = self.model.currentView
         # set figure bg color to match window

--- a/plotgui.py
+++ b/plotgui.py
@@ -390,11 +390,11 @@ class PlotImage(FigureCanvas):
 
             norm = SymLogNorm(1E-2) if cv.color_scale_log[cv.colorby] else None
             data = self.model.properties[:, :, idx]
-            self.image = self.figure.subplots().matshow(data,
-                                                        cmap=cmap,
-                                                        norm=norm,
-                                                        extent=data_bounds,
-                                                        alpha=cv.plotAlpha)
+            self.image = self.figure.subplots().imshow(data,
+                                                       cmap=cmap,
+                                                       norm=norm,
+                                                       extent=data_bounds,
+                                                       alpha=cv.plotAlpha)
             cmap_ax = self.figure.add_axes()
 
             # add colorbar

--- a/plotgui.py
+++ b/plotgui.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
+import sys
 
 from plot_colors import rgb_normalize, invert_rgb
 from plotmodel import DomainDelegate
@@ -36,14 +37,14 @@ class PlotImage(FigureCanvas):
 
     def __init__(self, model, parent, main):
 
-        super(FigureCanvas, self).__init__(Figure())
+        self.figure = Figure(dpi=main.logicalDpiX())
+        super(FigureCanvas, self).__init__(self.figure)
 
         FigureCanvas.setSizePolicy(self,
                                    QSizePolicy.Expanding,
                                    QSizePolicy.Expanding)
 
         FigureCanvas.updateGeometry(self)
-
         self.model = model
         self.mw = main
         self.parent = parent
@@ -356,10 +357,15 @@ class PlotImage(FigureCanvas):
         self.figure.patch.set_facecolor(rgb_normalize(window_bg.getRgb()))
 
         # set figure width
+        if sys.platform == 'darwin':
+            dpi = self.logicalDpiX()
+        else:
+            dpi = self.figure.get_dpi()
+            
         if w:
-            self.figure.set_figwidth(0.99 * w / self.figure.get_dpi())
+            self.figure.set_figwidth(0.99 * w / dpi)
         if h:
-            self.figure.set_figheight(0.99 * h / self.figure.get_dpi())
+            self.figure.set_figheight(0.99 * h / dpi)
         # set data extents for automatic reporting of pointer location
         data_bounds = [cv.origin[self.mw.xBasis] - cv.width/2.,
                        cv.origin[self.mw.xBasis] + cv.width/2.,

--- a/plotgui.py
+++ b/plotgui.py
@@ -363,16 +363,10 @@ class PlotImage(FigureCanvas):
         window_bg = self.parent.palette().color(QtGui.QPalette.Background)
         self.figure.patch.set_facecolor(rgb_normalize(window_bg.getRgb()))
 
-        # set figure width
-        if sys.platform == 'darwin':
-            dpi = self.logicalDpiX()
-        else:
-            dpi = self.figure.get_dpi()
-
         if w:
-            self.figure.set_figwidth(0.99 * w / dpi)
+            self.figure.set_figwidth(0.99 * w / self.figure.dpi)
         if h:
-            self.figure.set_figheight(0.99 * h / dpi)
+            self.figure.set_figheight(0.99 * h / self.figure.dpi)
         # set data extents for automatic reporting of pointer location
         data_bounds = [cv.origin[self.mw.xBasis] - cv.width/2.,
                        cv.origin[self.mw.xBasis] + cv.width/2.,

--- a/plotgui.py
+++ b/plotgui.py
@@ -104,6 +104,10 @@ class PlotImage(FigureCanvas):
 
         return (xPlotCoord, yPlotCoord)
 
+    def printPos(self, event):
+        print(event.x, event.y)
+        print(event.xdata, event.ydata)
+
     def getIDinfo(self, event):
 
         cv = self.model.currentView
@@ -235,6 +239,8 @@ class PlotImage(FigureCanvas):
             self.mw.editWidth(width)
             self.mw.editHeight(height)
 
+        FigureCanvas.mouseMoveEvent(self, event)
+
     def mouseReleaseEvent(self, event):
 
         if self.rubber_band.isVisible():
@@ -350,6 +356,8 @@ class PlotImage(FigureCanvas):
 
         # clear out figure
         self.figure.clear()
+        self.figure.canvas.mpl_connect('motion_notify_event', self.printPos)
+        self.figure.canvas.mpl_connect('button_press_event', self.printPos)
 
         cv = self.model.currentView
         # set figure bg color to match window
@@ -361,7 +369,7 @@ class PlotImage(FigureCanvas):
             dpi = self.logicalDpiX()
         else:
             dpi = self.figure.get_dpi()
-            
+
         if w:
             self.figure.set_figwidth(0.99 * w / dpi)
         if h:

--- a/plotgui.py
+++ b/plotgui.py
@@ -79,7 +79,7 @@ class PlotImage(FigureCanvas):
         self.rubber_band.setGeometry(QtCore.QRect(self.band_origin,
                                                   QtCore.QSize()))
 
-        FigureCanvas.mousePressEvent(self, event)
+#        FigureCanvas.mousePressEvent(self, event)
 
     def getPlotCoords(self, pos):
         x, y = self.mouseEventCoords(pos)
@@ -160,7 +160,7 @@ class PlotImage(FigureCanvas):
         xCenter, yCenter = self.getPlotCoords(event.pos())
         self.mw.editPlotOrigin(xCenter, yCenter, apply=True)
 
-        FigureCanvas.mouseDoubleClickEvent(self, event)
+#        FigureCanvas.mouseDoubleClickEvent(self, event)
 
     def mouseMoveEvent(self, event):
 
@@ -236,7 +236,7 @@ class PlotImage(FigureCanvas):
             self.mw.editWidth(width)
             self.mw.editHeight(height)
 
-        FigureCanvas.mouseMoveEvent(self, event)
+        self.draw()
 
     def mouseReleaseEvent(self, event):
 
@@ -246,6 +246,8 @@ class PlotImage(FigureCanvas):
         else:
             self.mw.revertDockControls()
 
+
+
     def wheelEvent(self, event):
 
         if event.delta() and event.modifiers() == QtCore.Qt.ShiftModifier:
@@ -253,6 +255,8 @@ class PlotImage(FigureCanvas):
 
             if 24 < self.mw.zoom + numDegrees < 5001:
                 self.mw.editZoom(self.mw.zoom + numDegrees)
+
+        self.draw()
 
     def contextMenuEvent(self, event):
 

--- a/plotgui.py
+++ b/plotgui.py
@@ -169,7 +169,7 @@ class PlotImage(FigureCanvas):
 
         # Show Cell/Material ID, Name in status bar
         id, properties, domain, domain_kind = self.getIDinfo(event)
-        if self.ax.contains_point((event.pos().x(), event.pos().y())):
+        if self.parent.underMouse():
 
             if domain_kind.lower() in _MODEL_PROPERTIES:
                 line_val = float(properties[domain_kind.lower()])

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -176,8 +176,10 @@ class PlotModel():
         minmax = {}
         for prop in _MODEL_PROPERTIES:
             idx = _PROPERTY_INDICES[prop]
-            minmax[prop] = (np.min(self.properties[:, :, idx]),
-                            np.max(self.properties[:, :, idx]))
+            prop_data = self.properties[:, :, idx]
+            minmax[prop] = (np.min(np.nan_to_num(prop_data)),
+                            np.max(np.nan_to_num(prop_data)))
+
         self.activeView.data_minmax = minmax
 
     def undo(self):


### PR DESCRIPTION
This branch started off as a set of fixes specifically for OSX, but now contains many updates/improvements including:

  - adjustments to figure sizing, labels (#18)
  - fix for colorbar scaling of data with `NaN`'s
  - consistent plot coordinates on Ubuntu/OSX
  - improved mouse over check for displaying coordinate values
  - fix so splash screen stays around until the main window is open and displayed
  - support for pinch zooming on OSX
  - new workflow for resizing the `FigureCanvas` object for smoother window sizing/zooming, only re-draws the image when color/id values have been regenerated in the model