### PR TITLE
Model reload and other loading fixes

### DIFF
--- a/plot_colors.py
+++ b/plot_colors.py
@@ -1,15 +1,19 @@
 
 import numpy as np
 
+
 # for consistent, but random, colors
 def reset_seed():
     np.random.seed(10)
 
+
 def random_rgb():
     return tuple(np.random.choice(range(256), size=3))
 
+
 def rgb_normalize(rgb):
     return tuple([c/255. for c in rgb])
+
 
 def invert_rgb(rgb, normalized=False):
     rgb_max = 1.0 if normalized else 255.

--- a/plot_colors.py
+++ b/plot_colors.py
@@ -2,7 +2,8 @@
 import numpy as np
 
 # for consistent, but random, colors
-np.random.seed(10)
+def reset_seed():
+    np.random.seed(10)
 
 def random_rgb():
     return tuple(np.random.choice(range(256), size=3))

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -765,11 +765,10 @@ class MainWindow(QMainWindow):
             with open('plot_settings.pkl', 'rb') as file:
                 model = pickle.load(file)
 
-            if model.defaultView == self.model.defaultView:
-                self.model.currentView = model.currentView
-                self.model.activeView = copy.deepcopy(model.currentView)
-                self.model.previousViews = model.previousViews
-                self.model.subsequentViews = model.subsequentViews
+        self.model.currentView = model.currentView
+        self.model.activeView = copy.deepcopy(model.currentView)
+        self.model.previousViews = model.previousViews
+        self.model.subsequentViews = model.subsequentViews
 
     def resetModels(self):
         self.cellsModel = DomainTableModel(self.model.activeView.cells)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -770,10 +770,10 @@ class MainWindow(QMainWindow):
             with open('plot_settings.pkl', 'rb') as file:
                 model = pickle.load(file)
 
-        self.model.currentView = model.currentView
-        self.model.activeView = copy.deepcopy(model.currentView)
-        self.model.previousViews = model.previousViews
-        self.model.subsequentViews = model.subsequentViews
+            self.model.currentView = model.currentView
+            self.model.activeView = copy.deepcopy(model.currentView)
+            self.model.previousViews = model.previousViews
+            self.model.subsequentViews = model.subsequentViews
 
     def resetModels(self):
         self.cellsModel = DomainTableModel(self.model.activeView.cells)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -34,7 +34,6 @@ class MainWindow(QMainWindow):
 
     def loadGui(self):
 
-        self.restored = False
         self.pixmap = None
         self.zoom = 100
 
@@ -84,12 +83,9 @@ class MainWindow(QMainWindow):
         self.dock.updateDock()
         self.colorDialog.updateDialogValues()
 
-        if self.restored:
-            self.showCurrentView()
-        else:
-            # Timer allows GUI to render before plot finishes loading
-            QtCore.QTimer.singleShot(0, self.plotIm.generatePixmap)
-            QtCore.QTimer.singleShot(0, self.showCurrentView)
+        # Timer allows GUI to render before plot finishes loading
+        QtCore.QTimer.singleShot(0, self.plotIm.generatePixmap)
+        QtCore.QTimer.singleShot(0, self.showCurrentView)
 
     def event(self, event):
         # use pinch event to update zoom
@@ -371,10 +367,12 @@ class MainWindow(QMainWindow):
     def loadModel(self, reload=False):
         if reload:
             self.statusBar().showMessage("Reloading model...")
+            # save settings (to be reloaded when model is reloaded)
             self.saveSettings()
 
         # create new plot model
         self.model = PlotModel()
+
         # update plot and model settings
         self.updateRelativeBases()
         self.restoreModelSettings()
@@ -772,9 +770,6 @@ class MainWindow(QMainWindow):
                 self.model.activeView = copy.deepcopy(model.currentView)
                 self.model.previousViews = model.previousViews
                 self.model.subsequentViews = model.subsequentViews
-                if os.path.isfile('plot_ids.binary') \
-                   and os.path.isfile('plot.ppm'):
-                    self.restored = True
 
     def resetModels(self):
         self.cellsModel = DomainTableModel(self.model.activeView.cells)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -373,15 +373,19 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage("Reloading model...")
             self.saveSettings()
 
+        # create new plot model
         self.model = PlotModel()
+        # update plot and model settings
         self.updateRelativeBases()
         self.restoreModelSettings()
 
         self.cellsModel = DomainTableModel(self.model.activeView.cells)
         self.materialsModel = DomainTableModel(self.model.activeView.materials)
 
+        # reset OpenMC memory, instances
         openmc.capi.reset()
         openmc.capi.finalize()
+        # initialize geometry (for volume calculation)
         openmc.capi.init(["-c"])
 
         if reload:

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -27,11 +27,11 @@ from overlays import ShortcutsOverlay
 
 
 def _openmcReload():
-            # reset OpenMC memory, instances
-            openmc.capi.reset()
-            openmc.capi.finalize()
-            # initialize geometry (for volume calculation)
-            openmc.capi.init(["-c"])
+    # reset OpenMC memory, instances
+    openmc.capi.reset()
+    openmc.capi.finalize()
+    # initialize geometry (for volume calculation)
+    openmc.capi.init(["-c"])
 
 
 class MainWindow(QMainWindow):

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -370,27 +370,17 @@ class MainWindow(QMainWindow):
         self.colorDialogAction.setChecked(self.colorDialog.isActiveWindow())
         self.mainWindowAction.setChecked(self.isActiveWindow())
 
-    # Menu and shared methods:
-
-    def loadModel(self, reload=False):
-        loader_thread = Thread(target=self._loadModel, args=(reload,))
-        loader_thread.start()
-        while loader_thread.is_alive():
-            if reload:
-                self.statusBar().showMessage("Reloading model...")
-            app.processEvents()
+    # Menu and shared methods
 
     def loadModel(self, reload=False):
         if reload:
-            # save settings (to be reloaded when model is reloaded)
-            self.saveSettings()
-
-        # create new plot model
-        self.model = PlotModel()
-
-        # update plot and model settings
-        self.updateRelativeBases()
-        self.restoreModelSettings()
+            self.resetModels()
+        else:
+            # create new plot model
+            self.model = PlotModel()
+            self.restoreModelSettings()
+            # update plot and model settings
+            self.updateRelativeBases()
 
         self.cellsModel = DomainTableModel(self.model.activeView.cells)
         self.materialsModel = DomainTableModel(self.model.activeView.materials)

--- a/plot_explorer.py
+++ b/plot_explorer.py
@@ -380,13 +380,12 @@ class MainWindow(QMainWindow):
         self.cellsModel = DomainTableModel(self.model.activeView.cells)
         self.materialsModel = DomainTableModel(self.model.activeView.materials)
 
-        # reset OpenMC memory, instances
-        openmc.capi.reset()
-        openmc.capi.finalize()
-        # initialize geometry (for volume calculation)
-        openmc.capi.init(["-c"])
-
         if reload:
+            # reset OpenMC memory, instances
+            openmc.capi.reset()
+            openmc.capi.finalize()
+            # initialize geometry (for volume calculation)
+            openmc.capi.init(["-c"])
             self.plotIm.model = self.model
             self.applyChanges()
 

--- a/plotgui.py
+++ b/plotgui.py
@@ -474,7 +474,7 @@ class PlotImage(FigureCanvas):
         av = self.model.activeView
         if self.colorbar and property_type == av.colorby:
             clim = av.getColorLimits(property_type)
-            self.colorbar.set_clim(*clim)
+            self.colorbar.mappable.set_clim(*clim)
             self.data_indicator.set_data(clim[:2],
                                          (0.0, 0.0))
             self.colorbar.draw_all()

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -71,9 +71,9 @@ class PlotModel():
 
         self.version = __VERSION__
 
-        # reset random number seed for coloring
+        # reset random number seed for consistent
+        # coloring when reloading a model
         reset_seed()
-
 
         self.previousViews = []
         self.subsequentViews = []

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -13,7 +13,7 @@ from PySide2.QtWidgets import (QTableView, QItemDelegate,
 from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt, QSize, QEvent
 from PySide2.QtGui import QColor
 
-from plot_colors import random_rgb
+from plot_colors import random_rgb, reset_seed
 
 ID, NAME, COLOR, COLORLABEL, MASK, HIGHLIGHT = tuple(range(0, 6))
 
@@ -70,6 +70,10 @@ class PlotModel():
         self.ids = None
 
         self.version = __VERSION__
+
+        # reset random number seed for coloring
+        reset_seed()
+
 
         self.previousViews = []
         self.subsequentViews = []


### PR DESCRIPTION
This PR enables model reloading so that geometry and/or materials can be updated and reloaded into the GUI without a shutdown and restart. Pretty nifty. Thanks for the suggestion @paulromano!

A couple other issues are addressed here as well:

  - consolidating OpenMC capi calls into a single function
  - fix for loading last view if `plot_settings.pkl` is present. We'll assume if it exists in the same directory as the model that it pertains to that model.
  - removing `restored` flag, this was used based on `plot.ppm` and `plot_ids.bin` files existing, now all we need is the plot settings file to restore state