### PR TITLE
Remove XML Reading

### DIFF
--- a/openmc-plotter
+++ b/openmc-plotter
@@ -6,6 +6,7 @@ from functools import partial
 import os
 from pathlib import Path
 import pickle
+import signal
 import sys
 from threading import Thread
 import time
@@ -946,4 +947,13 @@ if __name__ == '__main__':
     mainWindow.loadGui()
     mainWindow.show()
     splash.close()
+
+    # connect interrupt signal to close call
+    signal.signal(signal.SIGINT, lambda *args: mainWindow.close())
+    # create timer that interrupts the Qt event loop
+    # to check for a signal
+    timer = QtCore.QTimer()
+    timer.start(500)
+    timer.timeout.connect(lambda: None)
+
     sys.exit(app.exec_())

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -767,7 +767,7 @@ class MainWindow(QMainWindow):
         else:
             domain = self.model.activeView.materials
 
-        domain[id].highlighted = bool(state)
+        domain[id].highlight = bool(state)
         self.applyChanges()
 
     # Helper methods:

--- a/overlays.py
+++ b/overlays.py
@@ -21,7 +21,7 @@ class ShortcutsOverlay(QWidget):
                               ("Density", "Alt+D")],
                   "Views": [("Apply Changes", c_key + "+Enter"),
                             ("Undo", c_key + "+Z"),
-                            ("Redo", "Shift+Ctrl+Z"),
+                            ("Redo", "Shift+" + c_key+ "+Z"),
                             ("Restore Default Plot", c_key + "+R"),
                             ("Zoom", "Alt+Shift+Z"),
                             ("Zoom", "Shift+Scroll"),

--- a/plotgui.py
+++ b/plotgui.py
@@ -320,7 +320,7 @@ class PlotImage(FigureCanvas):
 
             highlightAction = self.menu.addAction('Highlight {}'.format(domain_kind))
             highlightAction.setCheckable(True)
-            highlightAction.setChecked(domain[id].highlighted)
+            highlightAction.setChecked(domain[id].highlight)
             highlightAction.setDisabled(not cv.highlighting)
             highlightAction.setToolTip('Toggle {} highlight'.format(domain_kind))
             highlightAction.setStatusTip('Toggle {} highlight'.format(domain_kind))

--- a/plotgui.py
+++ b/plotgui.py
@@ -145,11 +145,11 @@ class PlotImage(FigureCanvas):
         # check that the position is in the axes view
         if 0 <= yPos < self.model.currentView.v_res \
            and 0 <= xPos and xPos < self.model.currentView.h_res:
-            id = "{}".format(self.model.ids[yPos][xPos])
+            id = self.model.ids[yPos][xPos]
             temp = "{:g}".format(self.model.properties[yPos][xPos][0])
             density = "{:g}".format(self.model.properties[yPos][xPos][1])
         else:
-            id = str(_NOT_FOUND)
+            id = _NOT_FOUND
             density = str(_NOT_FOUND)
             temp = str(_NOT_FOUND)
 
@@ -196,18 +196,18 @@ class PlotImage(FigureCanvas):
             temperature = properties['temperature']
             density = properties['density']
 
-            if id == str(_VOID_REGION):
+            if id == _VOID_REGION:
                 domainInfo = ("VOID")
-            elif id == str(_OVERLAP):
+            elif id == _OVERLAP:
                 domainInfo = ("OVERLAP")
-            elif id != str(_NOT_FOUND) and domain[id].name:
+            elif id != _NOT_FOUND and domain[id].name:
                 domainInfo = ("{} {}: \"{}\"\t Density: {} g/cc\t"
                               "Temperature: {} K".format(domain_kind,
                                                          id,
                                                          domain[id].name,
                                                          density,
                                                          temperature))
-            elif id != str(_NOT_FOUND):
+            elif id != _NOT_FOUND:
                 domainInfo = ("{} {}\t Density: {} g/cc\t"
                               "Temperature: {} K".format(domain_kind,
                                                          id,

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -334,11 +334,12 @@ class PlotView(_PlotBase):
         if domain_type == 'cell':
             capi_domains = openmc.capi.cells
         elif domain_type == 'material':
-            capi_domains = openmc.capi.cells
+            capi_domains = openmc.capi.materials
 
         domains = {}
-        for domain in capi_domains:
-            domains[id] = DomainView(id, "", random_rgb(), False, False)
+        for domain, domain_obj in capi_domains.items():
+            name = domain_obj.name
+            domains[domain] = DomainView(domain, name, random_rgb())
 
         # always add void to a material domain at the end
         if domain_type == 'material':
@@ -390,11 +391,11 @@ class DomainView():
 
     def __repr__(self):
         return ("id: {} \nname: {} \ncolor: {} \
-                \nmask: {} \nhighlight: {}\n\n".format(self.id,
-                                                       self.name,
-                                                       self.color,
-                                                       self.masked,
-                                                       self.highlight))
+                \nmask: {} \nhighlighted: {}\n\n".format(self.id,
+                                                         self.name,
+                                                         self.color,
+                                                         self.masked,
+                                                         self.highlighted))
 
     def __eq__(self, other):
         if isinstance(other, DomainView):

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -167,7 +167,7 @@ class PlotModel():
 
         if cv.highlighting:
             for id, dom in domain.items():
-                if dom.highlighted:
+                if dom.highlight:
                     image[self.ids == int(id)] = cv.highlightBackground
 
         # set model image
@@ -330,14 +330,14 @@ class PlotView(_PlotBase):
             raise ValueError("Domain type, {}, requested is neither "
                              "'cell' nor 'material'.".format(domain_type))
 
-        capi_domains = None
+        capi_domain = None
         if domain_type == 'cell':
-            capi_domains = openmc.capi.cells
+            capi_domain = openmc.capi.cells
         elif domain_type == 'material':
-            capi_domains = openmc.capi.materials
+            capi_domain = openmc.capi.materials
 
         domains = {}
-        for domain, domain_obj in capi_domains.items():
+        for domain, domain_obj in capi_domain.items():
             name = domain_obj.name
             domains[domain] = DomainView(domain, name, random_rgb())
 
@@ -375,27 +375,27 @@ class DomainView():
     masked : bool
         Indication of whether cell/material should be masked
         (defaults to False)
-    highlighted : bool
+    highlight : bool
         Indication of whether cell/material should be highlighted
         (defaults to False)
     """
 
-    def __init__(self, id, name, color=None, masked=False, highlighted=False):
+    def __init__(self, id, name, color=None, masked=False, highlight=False):
         """ Initialize DomainView instance """
 
         self.id = id
         self.name = name
         self.color = color
         self.masked = masked
-        self.highlighted = highlighted
+        self.highlight = highlight
 
     def __repr__(self):
         return ("id: {} \nname: {} \ncolor: {} \
-                \nmask: {} \nhighlighted: {}\n\n".format(self.id,
+                \nmask: {} \nhighlight: {}\n\n".format(self.id,
                                                          self.name,
                                                          self.color,
                                                          self.masked,
-                                                         self.highlighted))
+                                                         self.highlight))
 
     def __eq__(self, other):
         if isinstance(other, DomainView):
@@ -463,7 +463,7 @@ class DomainTableModel(QAbstractTableModel):
             if column == MASK:
                 return Qt.Checked if domain.masked else Qt.Unchecked
             elif column == HIGHLIGHT:
-                return Qt.Checked if domain.highlighted else Qt.Unchecked
+                return Qt.Checked if domain.highlight else Qt.Unchecked
 
         return None
 
@@ -518,7 +518,7 @@ class DomainTableModel(QAbstractTableModel):
                 domain.masked = True if value == Qt.Checked else False
         elif column == HIGHLIGHT:
             if role == Qt.CheckStateRole:
-                domain.highlighted = True if value == Qt.Checked else False
+                domain.highlight = True if value == Qt.Checked else False
 
         self.dataChanged.emit(index, index)
         return True


### PR DESCRIPTION
This PR uses new CAPI capabilities added in [this OpenMC PR](https://github.com/openmc-dev/openmc/pull/1295) to remove reading of `.xml` files from the OpenMC plotting tool. This ensures that the model being viewed is consistent (not loaded from two different places).

It also adds the ability to exit the application from the terminal with a signal interrupt (`Ctrl-C`) (just for convenience), and changes the domain member `highlighted` to `highlight` for consistency in the code.

Finally, using CAPI ids made it easy to compare Cell/Material IDs as integers rather than strings, so I made that change here as well.