### PR TITLE
Persistent settings for view reset

### DIFF
--- a/openmc-plotter
+++ b/openmc-plotter
@@ -795,10 +795,8 @@ class MainWindow(QMainWindow):
                                                QtCore.QSize(400, 500)))
         self.colorDialog.move(settings.value("colorDialog/Position",
                                              QtCore.QPoint(600, 200)))
-
         is_visible = settings.value("colorDialog/Visible")
         is_visible = bool(is_visible)
-
         self.colorDialog.setVisible(is_visible)
 
     def restoreModelSettings(self):

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -785,8 +785,10 @@ class MainWindow(QMainWindow):
                                                QtCore.QSize(400, 500)))
         self.colorDialog.move(settings.value("colorDialog/Position",
                                              QtCore.QPoint(600, 200)))
-        is_visible = settings.value("colorDialog/Visible", 0)
-        is_visible = bool(int(is_visible))
+
+        is_visible = settings.value("colorDialog/Visible")
+        is_visible = bool(is_visible)
+
         self.colorDialog.setVisible(is_visible)
 
     def restoreModelSettings(self):

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -499,11 +499,7 @@ class MainWindow(QMainWindow):
             QApplication.processEvents()
 
             self.model.storeCurrent()
-            self.model.activeView = copy.deepcopy(self.model.defaultView)
-
-            # keep domain infomration from current view
-            self.model.activeView.cells = self.model.currentView.cells
-            self.model.activeView.materials = self.model.currentView.materials
+            self.model.activeView.adopt_plotbase(self.model.defaultView)
 
             self.plotIm.generatePixmap()
             self.resetModels()

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -790,8 +790,13 @@ class MainWindow(QMainWindow):
                                                QtCore.QSize(400, 500)))
         self.colorDialog.move(settings.value("colorDialog/Position",
                                              QtCore.QPoint(600, 200)))
-        is_visible = settings.value("colorDialog/Visible")
-        is_visible = bool(is_visible)
+        is_visible = settings.value("colorDialog/Visible", 0)
+        # some versions of PySide will return None rather than the default value
+        if is_visible is None:
+            is_visible = False
+        else:
+            is_visible = bool(int(is_visible))
+
         self.colorDialog.setVisible(is_visible)
 
     def restoreModelSettings(self):

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -712,6 +712,11 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
+    def resetColors(self):
+        self.model.resetColors()
+        self.colorDialog.updateDialogValues()
+        self.applyChanges()
+
     # Plot image methods
 
     def editPlotOrigin(self, xOr, yOr, zOr=None, apply=False):

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -500,6 +500,11 @@ class MainWindow(QMainWindow):
 
             self.model.storeCurrent()
             self.model.activeView = copy.deepcopy(self.model.defaultView)
+
+            # keep domain infomration from current view
+            self.model.activeView.cells = self.model.currentView.cells
+            self.model.activeView.materials = self.model.currentView.materials
+
             self.plotIm.generatePixmap()
             self.resetModels()
             self.showCurrentView()

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -856,7 +856,7 @@ class MainWindow(QMainWindow):
         self.zBasis = 3 - (self.xBasis + self.yBasis)
 
     def adjustWindow(self):
-        self.screen = app.desktop().screenGeometry()
+        self.screen = app.primaryScreen().size()
         self.setMaximumSize(self.screen.width(), self.screen.height())
 
     def onRatioChange(self):

--- a/openmc-plotter
+++ b/openmc-plotter
@@ -500,7 +500,6 @@ class MainWindow(QMainWindow):
 
             self.model.storeCurrent()
             self.model.activeView.adopt_plotbase(self.model.defaultView)
-
             self.plotIm.generatePixmap()
             self.resetModels()
             self.showCurrentView()

--- a/plotgui.py
+++ b/plotgui.py
@@ -837,6 +837,10 @@ class ColorDialog(QDialog):
 
         self.colorbyBox.currentTextChanged[str].connect(self.mw.editColorBy)
 
+        self.colorResetButton = QPushButton("&Reset Colors")
+        self.colorResetButton.setCursor(QtCore.Qt.PointingHandCursor)
+        self.colorResetButton.clicked.connect(self.mw.resetColors)
+
         formLayout = QFormLayout()
         formLayout.setAlignment(QtCore.Qt.AlignHCenter)
         formLayout.setFormAlignment(QtCore.Qt.AlignHCenter)
@@ -856,6 +860,7 @@ class ColorDialog(QDialog):
         formLayout.addRow('OVerlap Color:', self.overlapColorButton)
         formLayout.addRow(HorizontalLine())
         formLayout.addRow('Color Plot By:', self.colorbyBox)
+        formLayout.addRow(self.colorResetButton, None)
 
         generalLayout = QHBoxLayout()
         innerWidget = QWidget()

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -112,6 +112,15 @@ class PlotModel():
         default = PlotView([xcenter, ycenter, zcenter], width, height)
         return default
 
+    def resetColors(self):
+        reset_seed()
+        cv = self.activeView
+        for cell in cv.cells.values():
+            cell.color = random_rgb()
+
+        for material in cv.materials.values():
+            material.color = random_rgb()
+
     def generatePlot(self):
         """ Spawn thread from which to generate new plot image """
 

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -113,12 +113,13 @@ class PlotModel():
         return default
 
     def resetColors(self):
+        av = self.activeView
+
         reset_seed()
-        cv = self.activeView
-        for cell in cv.cells.values():
+        for cell in av.cells.values():
             cell.color = random_rgb()
 
-        for material in cv.materials.values():
+        for material in av.materials.values():
             material.color = random_rgb()
 
     def generatePlot(self):

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -371,6 +371,23 @@ class PlotView(_PlotBase):
             return self.data_minmax[property]
 
 
+    def adopt_plotbase(self, view):
+        """
+        Applies only the geometric aspects of a view to the current view
+
+        Parameters
+        ----------
+
+        view : PlotView
+            View to take parameters from
+        """
+        self.origin = view.origin
+        self.width = view.width
+        self.height = view.height
+        self.h_res = self.h_res
+        self.v_res = self.v_res
+        self.basis = view.basis
+
 class DomainView():
     """ Represents view settings for OpenMC cell or material.
 

--- a/plotmodel.py
+++ b/plotmodel.py
@@ -113,14 +113,9 @@ class PlotModel():
         return default
 
     def resetColors(self):
-        av = self.activeView
-
-        reset_seed()
-        for cell in av.cells.values():
-            cell.color = random_rgb()
-
-        for material in av.materials.values():
-            material.color = random_rgb()
+        """ Reset colors to those generated in the default view """
+        self.activeView.cells = self.defaultView.cells
+        self.activeView.materials = self.defaultView.materials
 
     def generatePlot(self):
         """ Spawn thread from which to generate new plot image """


### PR DESCRIPTION
This PR addresses #28.

When the default view is requested, only the geometric properties of the default view are updated. All settings (highlighting, masking, colors, etc.) from the active view will persist.

An option to reset colors now resides in the color dialog box, which will adopt the cell and material information of the default view (including their colors).

Other unrelated changes:

  - removed a deprecated call to `screenGeometry`
  - resolved a problem with retrieving the `colorDialog/Visible` property for the application. When that property was missing, `None` is returned and the conversion to int would fail. Given that the setting is stored as an integer, this conversion wasn't needed and could be removed. The missing application setting value will now evaluate to `False` and hide the color dialog - which is appropriate.
