### PR TITLE
Change openmc.capi -> openmc.lib

### DIFF
--- a/openmc-plotter
+++ b/openmc-plotter
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import copy
 from functools import partial
@@ -12,6 +11,7 @@ from threading import Thread
 import time
 
 import openmc
+import openmc.lib
 from PySide2 import QtCore, QtGui
 from PySide2.QtGui import QKeyEvent
 from PySide2.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
@@ -29,15 +29,15 @@ from overlays import ShortcutsOverlay
 
 def _openmcReload():
     # reset OpenMC memory, instances
-    openmc.capi.reset()
-    openmc.capi.finalize()
+    openmc.lib.reset()
+    openmc.lib.finalize()
     # initialize geometry (for volume calculation)
-    openmc.capi.init(["-c"])
+    openmc.lib.init(["-c"])
 
 
 class MainWindow(QMainWindow):
     def __init__(self):
-        super(MainWindow, self).__init__()
+        super().__init__()
 
         self.setWindowTitle('OpenMC Plot Explorer')
 
@@ -905,7 +905,7 @@ class MainWindow(QMainWindow):
         visible = int(self.colorDialog.isVisible())
         settings.setValue("colorDialog/Visible", visible)
 
-        openmc.capi.finalize()
+        openmc.lib.finalize()
 
         self.saveSettings()
 

--- a/plotgui.py
+++ b/plotgui.py
@@ -1,6 +1,3 @@
-#!/usr/bin/python3
-# -*- coding: utf-8 -*-
-
 from functools import partial
 
 from plot_colors import rgb_normalize, invert_rgb
@@ -495,7 +492,7 @@ class PlotImage(FigureCanvas):
 
 class OptionsDock(QDockWidget):
     def __init__(self, model, FM, parent=None):
-        super(OptionsDock, self).__init__(parent)
+        super().__init__(parent)
 
         self.model = model
         self.FM = FM
@@ -743,7 +740,7 @@ class OptionsDock(QDockWidget):
 class ColorDialog(QDialog):
 
     def __init__(self, model, FM, parent=None):
-        super(ColorDialog, self).__init__(parent)
+        super().__init__(parent)
 
         self.setWindowTitle('Color Options')
 
@@ -1099,6 +1096,6 @@ class ColorDialog(QDialog):
 
 class HorizontalLine(QFrame):
     def __init__(self):
-        super(HorizontalLine, self).__init__()
+        super().__init__()
         self.setFrameShape(QFrame.HLine)
         self.setFrameShadow(QFrame.Sunken)


### PR DESCRIPTION
Now that `openmc.capi` got renamed to `openmc.lib`, this PR simply updates the calls in the plotter to work accordingly.