### PR TITLE
Color Setting Performance

### DIFF
--- a/plotmodel.py
+++ b/plotmodel.py
@@ -188,9 +188,10 @@ class PlotModel():
 
         # construct image data
         domain[_OVERLAP] = DomainView(_OVERLAP, "Overlap", cv.overlap_color)
-        domain[_NOT_FOUND] = DomainView(_NOT_FOUND, "Not Found", cv.plotBackground)
-        u,inv = np.unique(self.ids, return_inverse=True)
-        image = np.array([domain[id].color for id in u])[inv].reshape((cv.v_res, cv.h_res, 3))
+        domain[_NOT_FOUND] = DomainView(_NOT_FOUND, "Not Found", cv.domainBackground)
+        u, inv = np.unique(self.ids, return_inverse=True)
+        image = np.array([domain[id].color for id in u])[inv]
+        image.shape = (cv.v_res, cv.h_res, 3)
 
         if cv.masking:
             for id, dom in domain.items():


### PR DESCRIPTION
@paulromano noticed that image generation slows way down for models with many unique ids in the view and isolated the culprit block of code. This PR addresses the problem by getting the indices of the unique ids along with the ids themselves in the original array. The unique ids and indices are then used to construct an image array -- populated with RGB color tuples instead of domain ids.