### PR TITLE
Allowing up to 9 digits in the height/width options.

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -127,11 +127,13 @@ class DomainDock(PlotterDock):
         # Width
         self.widthBox = QDoubleSpinBox(self)
         self.widthBox.setRange(.1, 99999)
+        self.widthBox.setDecimals(9)
         self.widthBox.valueChanged.connect(self.main_window.editWidth)
 
         # Height
         self.heightBox = QDoubleSpinBox(self)
         self.heightBox.setRange(.1, 99999)
+        self.widthBox.setDecimals(9)
         self.heightBox.valueChanged.connect(self.main_window.editHeight)
 
         # ColorBy


### PR DESCRIPTION
The default value of the spinbox seems to change based on the `PySide2` / `Qt` version (not sure which is the root of the problem. I recently found that my plotter was limited to 2 decimal places in the height/width parameters -- not great for examining small geometric features.

Probably best to go ahead and set this manually. The extra trailing zeros aren't super pretty, but functionally it's better than the alternative for now.