### PR TITLE
Plotting by universe level

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -145,6 +145,14 @@ class DomainDock(PlotterDock):
         self.colorbyBox.currentTextChanged[str].connect(
             self.main_window.editColorBy)
 
+        # Universe level (applies to cell coloring)
+        self.universeLevelBox = QComboBox(self)
+        self.universeLevelBox.addItem('lowest')
+        for i in range(self.model.max_universe_levels):
+            self.universeLevelBox.addItem(str(i))
+        self.universeLevelBox.currentTextChanged[str].connect(
+            self.main_window.editUniverseLevel)
+
         # Alpha
         self.domainAlphaBox = QDoubleSpinBox(self)
         self.domainAlphaBox.setValue(self.model.activeView.domainAlpha)
@@ -180,6 +188,7 @@ class DomainDock(PlotterDock):
         self.opLayout.addRow('Height:', self.heightBox)
         self.opLayout.addRow('Basis:', self.basisBox)
         self.opLayout.addRow('Color By:', self.colorbyBox)
+        self.opLayout.addRow('Universe Level', self.universeLevelBox)
         self.opLayout.addRow('Plot alpha:', self.domainAlphaBox)
         self.opLayout.addRow('Visible:', self.visibilityBox)
         self.opLayout.addRow('Outlines:', self.outlinesBox)
@@ -250,6 +259,13 @@ class DomainDock(PlotterDock):
 
     def updateColorBy(self):
         self.colorbyBox.setCurrentText(self.model.activeView.colorby)
+        if self.model.activeView.colorby != 'cell':
+            self.universeLevelBox.setEnabled(False)
+        else:
+            self.universeLevelBox.setEnabled(True)
+
+    def updateUniverseLevel(self):
+        self.universeLevelBox.setCurrentIndex(self.model.activeView.level + 1)
 
     def updatePlotAlpha(self):
         self.domainAlphaBox.setValue(self.model.activeView.domainAlpha)

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -238,6 +238,7 @@ class DomainDock(PlotterDock):
         self.updateWidth()
         self.updateHeight()
         self.updateColorBy()
+        self.updateUniverseLevel()
         self.updatePlotAlpha()
         self.updatePlotVisibility()
         self.updateOutlines()

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -145,9 +145,9 @@ class DomainDock(PlotterDock):
         self.colorbyBox.currentTextChanged[str].connect(
             self.main_window.editColorBy)
 
-        # Universe level (applies to cell coloring)
+        # Universe level (applies to cell coloring only)
         self.universeLevelBox = QComboBox(self)
-        self.universeLevelBox.addItem('lowest')
+        self.universeLevelBox.addItem('all')
         for i in range(self.model.max_universe_levels):
             self.universeLevelBox.addItem(str(i))
         self.universeLevelBox.currentTextChanged[str].connect(
@@ -188,7 +188,7 @@ class DomainDock(PlotterDock):
         self.opLayout.addRow('Height:', self.heightBox)
         self.opLayout.addRow('Basis:', self.basisBox)
         self.opLayout.addRow('Color By:', self.colorbyBox)
-        self.opLayout.addRow('Universe Level', self.universeLevelBox)
+        self.opLayout.addRow('Universe Level:', self.universeLevelBox)
         self.opLayout.addRow('Plot alpha:', self.domainAlphaBox)
         self.opLayout.addRow('Visible:', self.visibilityBox)
         self.opLayout.addRow('Outlines:', self.outlinesBox)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -26,6 +26,7 @@ from .docks import DomainDock, TallyDock
 from .overlays import ShortcutsOverlay
 from .tools import ExportDataDialog
 
+_COORD_LEVELS = 0
 
 def _openmcReload():
     # reset OpenMC memory, instances
@@ -34,7 +35,6 @@ def _openmcReload():
     # initialize geometry (for volume calculation)
     openmc.lib.settings.output_summary = False
     openmc.lib.init(["-c"])
-
 
 class MainWindow(QMainWindow):
     def __init__(self, font=QtGui.QFontMetrics(QtGui.QFont()), screen_size=QtCore.QSize()):
@@ -624,6 +624,15 @@ class MainWindow(QMainWindow):
         self.model.activeView.colorby = domain_kind
         self.dock.updateColorBy()
         self.colorDialog.updateColorBy()
+        if apply:
+            self.applyChanges()
+
+    def editUniverseLevel(self, level, apply=False):
+        if level == 'lowest':
+            self.model.activeView.level = -1
+        else:
+            self.model.activeView.level = int(level)
+        self.dock.updateUniverseLevel()
         if apply:
             self.applyChanges()
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -628,11 +628,12 @@ class MainWindow(QMainWindow):
             self.applyChanges()
 
     def editUniverseLevel(self, level, apply=False):
-        if level == 'lowest':
+        if level == 'all':
             self.model.activeView.level = -1
         else:
             self.model.activeView.level = int(level)
         self.dock.updateUniverseLevel()
+        self.colorDialog.updateUniverseLevel()
         if apply:
             self.applyChanges()
 

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -979,6 +979,7 @@ class ColorDialog(QDialog):
         self.updateSeed()
         self.updateBackgroundColor()
         self.updateColorBy()
+        self.updateUniverseLevel()
         self.updateDomainTabs()
         self.updateOverlap()
         self.updateOverlapColor()
@@ -1059,7 +1060,10 @@ class ColorDialog(QDialog):
 
     def updateUniverseLevel(self):
         level = self.model.activeView.level
-        self.universeLevelBox.setCurrentText(level)
+        if level == -1:
+            self.universeLevelBox.setCurrentText('all')
+        else:
+            self.universeLevelBox.setCurrentText(str(level))
 
     def updateDomainTabs(self):
         self.cellTable.setModel(self.main_window.cellsModel)

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -776,6 +776,13 @@ class ColorDialog(QDialog):
         self.colorbyBox.addItem("cell")
         self.colorbyBox.addItem("temperature")
         self.colorbyBox.addItem("density")
+        self.colorbyBox.currentTextChanged[str].connect(main_window.editColorBy)
+
+        self.universeLevelBox = QComboBox(self)
+        self.universeLevelBox.addItem('all')
+        for i in range(self.model.max_universe_levels):
+            self.universeLevelBox.addItem(str(i))
+        self.universeLevelBox.currentTextChanged[str].connect(main_window.editUniverseLevel)
 
         # Overlap plotting
         self.overlapCheck = QCheckBox('', self)
@@ -787,8 +794,6 @@ class ColorDialog(QDialog):
         self.overlapColorButton.setFixedWidth(self.font_metric.width("XXXXXXXXXX"))
         self.overlapColorButton.setFixedHeight(self.font_metric.height() * 1.5)
         self.overlapColorButton.clicked.connect(main_window.editOverlapColor)
-
-        self.colorbyBox.currentTextChanged[str].connect(main_window.editColorBy)
 
         self.colorResetButton = QPushButton("&Reset Colors")
         self.colorResetButton.setCursor(QtCore.Qt.PointingHandCursor)
@@ -813,6 +818,7 @@ class ColorDialog(QDialog):
         formLayout.addRow('OVerlap Color:', self.overlapColorButton)
         formLayout.addRow(HorizontalLine())
         formLayout.addRow('Color Plot By:', self.colorbyBox)
+        formLayout.addRow('Universe Level:', self.universeLevelBox)
         formLayout.addRow(self.colorResetButton, None)
 
         generalLayout = QHBoxLayout()
@@ -1049,6 +1055,11 @@ class ColorDialog(QDialog):
         colorby = self.model.activeView.colorby
         self.colorbyBox.setCurrentText(colorby)
         self.overlapCheck.setEnabled(colorby in ("cell", "material"))
+        self.universeLevelBox.setEnabled(colorby == 'cell')
+
+    def updateUniverseLevel(self):
+        level = self.model.activeView.level
+        self.universeLevelBox.setCurrentText(level)
 
     def updateDomainTabs(self):
         self.cellTable.setModel(self.main_window.cellsModel)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -171,9 +171,7 @@ class PlotModel():
         else:
             zcenter = 0.00
 
-        level = self.max_universe_levels
-
-        default = PlotView([xcenter, ycenter, zcenter], width, height, level)
+        default = PlotView([xcenter, ycenter, zcenter], width, height)
         return default
 
     def resetColors(self):
@@ -656,13 +654,13 @@ class PlotView(openmc.lib.plot._PlotBase):
         Label of the currently selected tally
     """
 
-    def __init__(self, origin, width, height, level):
+    def __init__(self, origin, width, height):
         """ Initialize PlotView attributes """
 
         super().__init__()
 
         # View Parameters
-        self.level = level
+        self.level = -1
         self.origin = origin
         self.width = width
         self.height = height

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -96,6 +96,7 @@ class PlotModel():
         # Retrieve OpenMC Cells/Materials
         self.modelCells = openmc.lib.cells
         self.modelMaterials = openmc.lib.materials
+        self.max_universe_levels = openmc.lib._coord_levels()
 
         # Cell/Material ID by coordinates
         self.ids = None
@@ -170,7 +171,9 @@ class PlotModel():
         else:
             zcenter = 0.00
 
-        default = PlotView([xcenter, ycenter, zcenter], width, height)
+        level = self.max_universe_levels
+
+        default = PlotView([xcenter, ycenter, zcenter], width, height, level)
         return default
 
     def resetColors(self):
@@ -653,13 +656,13 @@ class PlotView(openmc.lib.plot._PlotBase):
         Label of the currently selected tally
     """
 
-    def __init__(self, origin, width, height):
+    def __init__(self, origin, width, height, level):
         """ Initialize PlotView attributes """
 
         super().__init__()
 
         # View Parameters
-        self.level = -1
+        self.level = level
         self.origin = origin
         self.width = width
         self.height = height
@@ -791,7 +794,7 @@ class PlotView(openmc.lib.plot._PlotBase):
         else:
             x = self.origin[0] + self.width / 2.0
             y = self.origin[1]
-            z = self.origin[2] + height / 2.0
+            z = self.origin[2] + self.height / 2.0
         return x, y, z
 
     def adopt_plotbase(self, view):


### PR DESCRIPTION
These changes rely on https://github.com/openmc-dev/openmc/pull/1651 to get the maximum number of universe levels in the geometry. By default, the highest level cell is plotted for a given pixel (the 'all' option). Individual levels can be selected as well.

This is particularly important for visualizing tallies with cell filters containing cells in lower levels of the geometry.