### PR TITLE
GHA Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+
+env:
+  OMP_NUM_THREADS: 2
+  QT_QPA_PLATFORM: offscreen
+
+jobs:
+  ci:
+    container: openmc/openmc:v0.12.1
+
+  steps:
+    -
+      name: Apt dependencies
+      shell: bash
+      run: sudo apt install -y libgl1-mesa
+    -
+      uses: actions/checkout@v2
+    -
+      name: Install
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        pip install .[test]
+    -
+      name: Test
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        pytest -v tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ on:
   pull_request:
     branches:
       - develop
-      - main
+      - master
   push:
     branches:
       - develop
-      - main
+      - master
 
 env:
   OMP_NUM_THREADS: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       -
         name: Apt dependencies
         shell: bash
-        run: apt install -y libgl1-mesa
+        run: |
+          apt update
+          apt install -y libgl1-mesa
       -
         uses: actions/checkout@v2
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,24 +19,24 @@ env:
 
 jobs:
   ci:
+    runs-on: ubuntu-latest
     container: openmc/openmc:v0.12.1
-
-  steps:
-    -
-      name: Apt dependencies
-      shell: bash
-      run: sudo apt install -y libgl1-mesa
-    -
-      uses: actions/checkout@v2
-    -
-      name: Install
-      shell: bash
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        pip install .[test]
-    -
-      name: Test
-      shell: bash
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        pytest -v tests
+    steps:
+      - 
+        name: Apt dependencies
+        shell: bash
+        run: sudo apt install -y libgl1-mesa
+      -
+        uses: actions/checkout@v2
+      -
+        name: Install
+        shell: bash
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          pip install .[test]
+      -
+        name: Test
+        shell: bash
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          pytest -v tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    container: openmc/openmc:v0.12.1
+    container: openmc/openmc:develop
     steps:
       -
         name: Apt dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     container: openmc/openmc:v0.12.1
     steps:
-      - 
+      -
         name: Apt dependencies
         shell: bash
-        run: sudo apt install -y libgl1-mesa
+        run: apt install -y libgl1-mesa
       -
         uses: actions/checkout@v2
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y libgl1-mesa
+          apt install -y libglu1-mesa
       -
         uses: actions/checkout@v2
       -

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -8,7 +8,7 @@ name: Upload Python Package
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -8,7 +8,7 @@ name: Upload Python Package
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
This adds a CI file to run the single test we have on CI for PRs into `develop` and `master`. 

It also updates one of the PyPI scripts to no longer trigger on the `develop` branch. PyPI requires a new version each time it is run, so it doesn't make sense to run it for every PR merge. If there's a better way to handle that @Shimwell, let us know!