### PR TITLE
Fix deprecation warning on QFontMetrics.width

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -336,7 +336,7 @@ class TallyDock(PlotterDock):
         self.tallyGroupBox.setLayout(self.tallySelectorLayout)
 
         # Create submit button
-        self.applyButton = QPushButton("ApplyChanges")
+        self.applyButton = QPushButton("Apply Changes")
         self.applyButton.setMinimumHeight(self.font_metric.height() * 1.6)
         self.applyButton.clicked.connect(self.main_window.applyChanges)
 

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -736,9 +736,10 @@ class ColorDialog(QDialog):
         self.maskingCheck = QCheckBox('')
         self.maskingCheck.stateChanged.connect(main_window.toggleMasking)
 
+        button_width = self.font_metric.boundingRect("XXXXXXXXXX").width()
         self.maskColorButton = QPushButton()
         self.maskColorButton.setCursor(QtCore.Qt.PointingHandCursor)
-        self.maskColorButton.setFixedWidth(self.font_metric.width("XXXXXXXXXX"))
+        self.maskColorButton.setFixedWidth(button_width)
         self.maskColorButton.setFixedHeight(self.font_metric.height() * 1.5)
         self.maskColorButton.clicked.connect(main_window.editMaskingColor)
 
@@ -748,7 +749,7 @@ class ColorDialog(QDialog):
 
         self.hlColorButton = QPushButton()
         self.hlColorButton.setCursor(QtCore.Qt.PointingHandCursor)
-        self.hlColorButton.setFixedWidth(self.font_metric.width("XXXXXXXXXX"))
+        self.hlColorButton.setFixedWidth(button_width)
         self.hlColorButton.setFixedHeight(self.font_metric.height() * 1.5)
         self.hlColorButton.clicked.connect(main_window.editHighlightColor)
 
@@ -764,7 +765,7 @@ class ColorDialog(QDialog):
         # General options
         self.bgButton = QPushButton()
         self.bgButton.setCursor(QtCore.Qt.PointingHandCursor)
-        self.bgButton.setFixedWidth(self.font_metric.width("XXXXXXXXXX"))
+        self.bgButton.setFixedWidth(button_width)
         self.bgButton.setFixedHeight(self.font_metric.height() * 1.5)
         self.bgButton.clicked.connect(main_window.editBackgroundColor)
 
@@ -788,7 +789,7 @@ class ColorDialog(QDialog):
 
         self.overlapColorButton = QPushButton()
         self.overlapColorButton.setCursor(QtCore.Qt.PointingHandCursor)
-        self.overlapColorButton.setFixedWidth(self.font_metric.width("XXXXXXXXXX"))
+        self.overlapColorButton.setFixedWidth(button_width)
         self.overlapColorButton.setFixedHeight(self.font_metric.height() * 1.5)
         self.overlapColorButton.clicked.connect(main_window.editOverlapColor)
 

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -813,7 +813,7 @@ class ColorDialog(QDialog):
         formLayout.addRow('Background Color:          ', self.bgButton)
         formLayout.addRow(HorizontalLine())
         formLayout.addRow('Show Overlaps:', self.overlapCheck)
-        formLayout.addRow('OVerlap Color:', self.overlapColorButton)
+        formLayout.addRow('Overlap Color:', self.overlapColorButton)
         formLayout.addRow(HorizontalLine())
         formLayout.addRow('Color Plot By:', self.colorbyBox)
         formLayout.addRow('Universe Level:', self.universeLevelBox)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -984,13 +984,13 @@ class DomainDelegate(QItemDelegate):
         column = index.column()
 
         if column == ID:
-            return QSize(fm.width("XXXXXX"), fm.height())
+            return QSize(fm.boundingRect("XXXXXX").width(), fm.height())
         elif column == COLOR:
-            return QSize(fm.width("XXXXXX"), fm.height())
+            return QSize(fm.boundingRect("XXXXXX").width(), fm.height())
         elif column == COLORLABEL:
-            return QSize(fm.width("X(XXX, XXX, XXX)X"), fm.height())
+            return QSize(fm.boundingRect("X(XXX, XXX, XXX)X").width(), fm.height())
         elif column == MASK:
-            return QSize(fm.width("XXXX"), fm.height())
+            return QSize(fm.boundingRect("XXXX").width(), fm.height())
         else:
             return QItemDelegate.sizeHint(self, option, index)
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -4,7 +4,7 @@ import itertools
 import threading
 from ast import literal_eval
 
-from PySide2.QtWidgets import QItemDelegate, QColorDialog, QLineEdit
+from PySide2.QtWidgets import QItemDelegate, QColorDialog, QLineEdit, QMessageBox
 from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt, QSize, QEvent
 from PySide2.QtGui import QColor
 import openmc


### PR DESCRIPTION
You might have noticed that in the test that's run, there's a deprecation warning for the use of `QFontMetrics.width`. Based on [this discussion](https://kdepepo.wordpress.com/2019/08/05/about-deprecation-of-qfontmetricswidth/), I've replaced it with `QFontMetrics.boundingRect(...).width()`. Also fixed some labels and a missing import.