### PR TITLE
Support 2D meshes, energy function filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y libglu1-mesa
+          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1
       -
         uses: actions/checkout@v2
       -

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -412,7 +412,12 @@ class TallyDock(PlotterDock):
                 else:
                     return bin
 
-            for bin in sorted(tally_filter.bins, key=_bin_sort_val):
+            if isinstance(tally_filter, openmc.EnergyFunctionFilter):
+                bins = [0]
+            else:
+                bins = tally_filter.bins
+
+            for bin in sorted(bins, key=_bin_sort_val):
                 item = QTreeWidgetItem(filter_item, [str(bin),])
                 if not spatial_filters:
                     item.setFlags(QtCore.Qt.ItemIsUserCheckable)
@@ -577,7 +582,11 @@ class TallyDock(PlotterDock):
             filter_checked = f_item.checkState(0)
             if filter_checked != QtCore.Qt.Unchecked:
                 selected_bins = []
-                for idx, b in enumerate(f.bins):
+                if isinstance(f, openmc.EnergyFunctionFilter):
+                    bins = [0]
+                else:
+                    bins = f.bins
+                for idx, b in enumerate(bins):
                     b = b if not isinstance(b, Iterable) else tuple(b)
                     bin_checked = self.bin_map[(f, b)].checkState(0)
                     if bin_checked == QtCore.Qt.Checked:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 qt_api=pyside2
 python_files = test*.py
 python_classes = NoThanks
-filter_warnings = ignore::UserWarning
+filterwarnings = ignore::UserWarning
 addopts = -rs

--- a/tests/setup_test/test.py
+++ b/tests/setup_test/test.py
@@ -1,5 +1,3 @@
-import openmc.lib
-
 from openmc_plotter.main_window import MainWindow, _openmcReload
 
 def test_window(qtbot):


### PR DESCRIPTION
This PR adds support for plotting tally results when a mesh filter with a 2D mesh is used. I've also fixed a bug whereby a tally with an EnergyFunctionFilter would cause an exception to be raised.