### PR TITLE
Removing unused matplotlib backend query.

### DIFF
--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -6,7 +6,6 @@ from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
                                QDoubleSpinBox, QSizePolicy, QMessageBox,
                                QCheckBox, QRubberBand, QMenu, QDialog,
                                QTabWidget, QTableView, QHeaderView)
-from matplotlib.backends.qt_compat import is_pyqt5
 from matplotlib.figure import Figure
 from matplotlib import lines as mlines
 from matplotlib import cm as mcolormaps


### PR DESCRIPTION
Matplotlib v3.5.0 has deprecated the `qt_compat.is_pyqt5` method, which is present in `plotgui.py` but is unused. This removes it.