### PR TITLE
Remove superfluous install of OpenMC Python API during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
       -
         uses: actions/checkout@v2
       -
-        name: Install OpenMC Python API
-        shell: bash
-        run: |
-          cd /root/OpenMC/openmc
-          pip install .[test]
-      -
         name: Install
         shell: bash
         run: |


### PR DESCRIPTION
Now that the OpenMC docker image installs the Python API properly, we shouldn't need to do anything special during CI