### PR TITLE
Fix filter bin selection performance bug

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -381,7 +381,6 @@ class TallyDock(PlotterDock):
         self.filterTree.setHeaderItem(header)
         self.filterTree.setItemHidden(header, True)
         self.filterTree.setColumnCount(1)
-        self.filterTree.itemChanged.connect(self.updateFilters)
 
         self.filter_map = {}
         self.bin_map = {}
@@ -489,8 +488,6 @@ class TallyDock(PlotterDock):
 
             # scores
             self.score_map = {}
-            self.scoresListWidget.itemClicked.connect(
-                self.main_window.updateScores)
             self.score_map.clear()
             self.scoresListWidget.clear()
 
@@ -525,7 +522,6 @@ class TallyDock(PlotterDock):
 
             # nuclides
             self.nuclide_map = {}
-            self.nuclidesListWidget.itemClicked.connect(self.main_window.updateNuclides)
             self.nuclide_map.clear()
             self.nuclidesListWidget.clear()
 
@@ -574,13 +570,27 @@ class TallyDock(PlotterDock):
         self.tallySelector.setCurrentIndex(idx)
 
     def updateFilters(self):
+        # if the filters header is checked, uncheck all bins and return
         applied_filters = defaultdict(tuple)
         for f, f_item in self.filter_map.items():
             if type(f) == openmc.MeshFilter:
                 continue
 
             filter_checked = f_item.checkState(0)
-            if filter_checked != QtCore.Qt.Unchecked:
+            if filter_checked == QtCore.Qt.Unchecked:
+                for i in range(f_item.childCount()):
+                    bin_item = f_item.child(i)
+                    bin_item.setCheckState(0, QtCore.Qt.Unchecked)
+                applied_filters[f] = tuple()
+            elif filter_checked == QtCore.Qt.Checked:
+                if isinstance(f, openmc.EnergyFunctionFilter):
+                    bins = [0]
+                else:
+                    for i in range(f_item.childCount()):
+                        bin_item = f_item.child(i)
+                        bin_item.setCheckState(0, QtCore.Qt.Checked)
+                    applied_filters[f] = tuple(i for i in range(f_item.childCount()))
+            elif filter_checked == QtCore.Qt.PartiallyChecked:
                 selected_bins = []
                 if isinstance(f, openmc.EnergyFunctionFilter):
                     bins = [0]
@@ -593,7 +603,7 @@ class TallyDock(PlotterDock):
                         selected_bins.append(idx)
                 applied_filters[f] = tuple(selected_bins)
 
-            self.model.appliedFilters = applied_filters
+        self.model.appliedFilters = applied_filters
 
     def updateScores(self):
         applied_scores = []
@@ -648,6 +658,11 @@ class TallyDock(PlotterDock):
                 empty_item = QListWidgetItem()
                 nuclide_box.setFlags(empty_item.flags() | QtCore.Qt.ItemIsUserCheckable)
                 nuclide_box.setFlags(empty_item.flags() & ~QtCore.Qt.ItemIsSelectable)
+
+    def updateModel(self):
+        self.updateFilters()
+        self.updateScores()
+        self.updateNuclides()
 
     def update(self):
 

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -589,7 +589,7 @@ class TallyDock(PlotterDock):
                     for i in range(f_item.childCount()):
                         bin_item = f_item.child(i)
                         bin_item.setCheckState(0, QtCore.Qt.Checked)
-                    applied_filters[f] = tuple(i for i in range(f_item.childCount()))
+                    applied_filters[f] = tuple(range(f_item.childCount()))
             elif filter_checked == QtCore.Qt.PartiallyChecked:
                 selected_bins = []
                 if isinstance(f, openmc.EnergyFunctionFilter):

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -585,6 +585,8 @@ class MainWindow(QMainWindow):
         if self.model.activeView != self.model.currentView:
             self.statusBar().showMessage('Generating Plot...')
             QApplication.processEvents()
+            if self.model.activeView.selectedTally is not None:
+                self.tallyDock.updateModel()
             self.model.storeCurrent()
             self.model.subsequentViews = []
             self.plotIm.generatePixmap()
@@ -900,12 +902,6 @@ class MainWindow(QMainWindow):
     def editTallyValue(self, event):
         av = self.model.activeView
         av.tallyValue = event
-
-    def updateScores(self, state):
-        self.tallyDock.updateScores()
-
-    def updateNuclides(self, state):
-        self.tallyDock.updateNuclides()
 
     def toggleTallyVisibility(self, state, apply=False):
         av = self.model.activeView

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -541,8 +541,8 @@ class PlotModel():
             if type(tally_filter) == openmc.MeshFilter:
                 continue
 
-            if tally_filter in self.appliedFilters:
-                selected_bins = self.appliedFilters[tally_filter]
+            selected_bins = self.appliedFilters[tally_filter]
+            if selected_bins:
                 # sum filter data for the selected bins
                 data = data[np.array(selected_bins)].sum(axis=0)
             else:


### PR DESCRIPTION
I noticed that it takes a very long time to unselect an entire category of bins in the plotter. This is caused by each bin making a call to the `TallyDock.updateFilters` method, which results in a lot of wasted calculation.

This PR removes callback connections to the filter, scores, and nuclides trees and reads the state of the trees using `TallyDock.updateModel` only when a new plot is generated (i.e. `Apply Changes` is clicked). It also updates the `TallyDock.updateFilters` method with logic if for filters where all or none of the bins are selected to improve speed.

