### PR TITLE
Allow execution from a different directotry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,16 @@ pip install openmc-plotter
 From a directory containing an OpenMC model run:
 
 ```console
-openmc-plotter
+$ openmc-plotter -d <path_to_openmc_model_dir>
 ```
+
+or simply run
+
+```console
+$ openmc-plotter
+```
+
+from the directory containing the model.
 
 Once the viewer has opened, press `?` to view a variety of keyboard shortcuts.
 

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -22,6 +22,9 @@ def main():
     if args.model_directory is not None:
         os.chdir(args.model_directory)
 
+    run_app()
+
+
 def run_app():
     path_icon = str(Path(__file__).parent / 'assets/openmc_logo.png')
     path_splash = str(Path(__file__).parent / 'assets/splash.png')

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -1,7 +1,9 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
+from argparse import ArgumentParser
 from pathlib import Path
 from threading import Thread
+import os
 import signal
 import sys
 
@@ -11,6 +13,16 @@ from PySide2.QtWidgets import QApplication, QSplashScreen
 from .main_window import MainWindow, _openmcReload
 
 def main():
+    ap = ArgumentParser(description='OpenMC Plotter GUI')
+    ap.add_argument('-d','--model-directory', default=None,
+                    help='Location of model dir (default is current dir)')
+
+    args = ap.parse_args()
+
+    if args.model_directory is not None:
+        os.chdir(args.model_directory)
+
+def run_app():
     path_icon = str(Path(__file__).parent / 'assets/openmc_logo.png')
     path_splash = str(Path(__file__).parent / 'assets/splash.png')
 

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -14,13 +14,12 @@ from .main_window import MainWindow, _openmcReload
 
 def main():
     ap = ArgumentParser(description='OpenMC Plotter GUI')
-    ap.add_argument('-d','--model-directory', default=None,
+    ap.add_argument('-d', '--model-directory', default=os.curdir,
                     help='Location of model dir (default is current dir)')
 
     args = ap.parse_args()
 
-    if args.model_directory is not None:
-        os.chdir(args.model_directory)
+    os.chdir(args.model_directory)
 
     run_app()
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -35,6 +35,7 @@ def _openmcReload():
     # initialize geometry (for volume calculation)
     openmc.lib.settings.output_summary = False
     openmc.lib.init(["-c"])
+    openmc.lib.settings.verbosity = 1
 
 class MainWindow(QMainWindow):
     def __init__(self, font=QtGui.QFontMetrics(QtGui.QFont()), screen_size=QtCore.QSize()):


### PR DESCRIPTION
This adds an option to specify the location of the OpenMC model and execute the plotter from any location. Maybe I'm just lazy, but I've wanted to do this a number of times when I'm comparing two models and don't want to switch back and forth between the directories.

I've also set the verbosity to `1` always here, so we don't get a bunch of `Entering cell X` messages if the settings file has a non-default verbosity value set.