### PR TITLE
Adding option to ignore the plot_settings.pkl file

### DIFF
--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -17,7 +17,7 @@ def main():
     ap.add_argument('-d','--model-directory', default=None,
                     help='Location of model dir (default is current dir)')
     ap.add_argument('-e','--ignore-settings', action='store_false',
-                    help='Ignore plot_settings.pkl file if flag is present.')
+                    help='Ignore plot_settings.pkl file if present.')
 
     args = ap.parse_args()
 

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -16,16 +16,18 @@ def main():
     ap = ArgumentParser(description='OpenMC Plotter GUI')
     ap.add_argument('-d','--model-directory', default=None,
                     help='Location of model dir (default is current dir)')
+    ap.add_argument('-e','--ignore-settings', action='store_false',
+                    help='Ignore plot_settings.pkl file if flag is present.')
 
     args = ap.parse_args()
 
     if args.model_directory is not None:
         os.chdir(args.model_directory)
 
-    run_app()
+    run_app(use_settings_pkl=args.ignore_settings)
 
 
-def run_app():
+def run_app(use_settings_pkl=True):
     path_icon = str(Path(__file__).parent / 'assets/openmc_logo.png')
     path_splash = str(Path(__file__).parent / 'assets/splash.png')
 
@@ -61,7 +63,7 @@ def run_app():
     screen_size = app.primaryScreen().size()
     mainWindow = MainWindow(font_metric, screen_size)
     # connect splashscreen to main window, close when main window opens
-    mainWindow.loadGui()
+    mainWindow.loadGui(use_settings_pkl=use_settings_pkl)
     mainWindow.show()
     splash.close()
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -38,19 +38,21 @@ def _openmcReload():
     openmc.lib.settings.verbosity = 1
 
 class MainWindow(QMainWindow):
-    def __init__(self, font=QtGui.QFontMetrics(QtGui.QFont()), screen_size=QtCore.QSize()):
+    def __init__(self,
+                 font=QtGui.QFontMetrics(QtGui.QFont()),
+                 screen_size=QtCore.QSize()):
         super().__init__()
 
         self.screen = screen_size
         self.font_metric = font
         self.setWindowTitle('OpenMC Plot Explorer')
 
-    def loadGui(self):
+    def loadGui(self, use_settings_pkl=True):
 
         self.pixmap = None
         self.zoom = 100
 
-        self.loadModel()
+        self.loadModel(use_settings_pkl=use_settings_pkl)
 
         # Create viewing area
         self.frame = QScrollArea(self)
@@ -439,13 +441,14 @@ class MainWindow(QMainWindow):
         self.mainWindowAction.setChecked(self.isActiveWindow())
 
     # Menu and shared methods
-    def loadModel(self, reload=False):
+    def loadModel(self, reload=False, use_settings_pkl=True):
         if reload:
             self.resetModels()
         else:
             # create new plot model
             self.model = PlotModel()
-            self.restoreModelSettings()
+            if use_settings_pkl:
+                self.restoreModelSettings()
             # update plot and model settings
             self.updateRelativeBases()
 


### PR DESCRIPTION
Another convenience PR. If domain IDs change, we get a bunch of key errors when trying to lookup their colors in the `DomainModel`'s loaded from the `plot_settings.pkl`. The better long-term solution is to provide better detection for the validity of the settings file when starting the plotter, but for now this will at least let one start the plotter without having to remove this file manually.