### PR TITLE
fix duplicate calls to makePlot() on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 __pycache__
 plot_settings.pkl
+*.egg-info
+build/

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -409,10 +409,6 @@ class MainWindow(QMainWindow):
         changed = self.model.currentView != self.model.defaultView
         self.restoreAction.setDisabled(not changed)
 
-        self.maskingAction.setChecked(self.model.currentView.masking)
-        self.highlightingAct.setChecked(self.model.currentView.highlighting)
-        self.outlineAct.setChecked(self.model.currentView.outlines)
-
         num_previous_views = len(self.model.previousViews)
         self.undoAction.setText('&Undo ({})'.format(num_previous_views))
         num_subsequent_views = len(self.model.subsequentViews)


### PR DESCRIPTION
This addresses #67. See discussion there for why these lines were causing multiple loading of the plot.

Removal of these 3 lines means that the state of these three toggled options in the Edit menu are not saved for the next time the window is opened. If we want the behavior to be such that the state is saved, then I don't think we can get around this duplicate loading issue (which can happen up to 3 times, one for each toggled option). If people are okay with that state not being saved, then it should be as simple as just removing these three lines to fix it.