### PR TITLE
Adding support for viewing distribcell tallies

### DIFF
--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -282,11 +282,17 @@ class PlotModel():
 
     def create_tally_image(self, view=None):
         """
+        Parameters
+        ----------
+        view :
+            View used to set bounds of the tally data
+
         Returns
         -------
-        tuple : image data (numpy.ndarray), data extents (optional),
-                data_min_value (float), data_max_value (float),
-                data label (str)
+        tuple
+            image data (numpy.ndarray), data extents (optional),
+            data_min_value (float), data_max_value (float),
+            data label (str)
         """
         if view is None:
             view = self.currentView
@@ -387,13 +393,11 @@ class PlotModel():
                 mean_data = self._create_tally_domain_image(tally,
                                                             'mean',
                                                             scores,
-                                                            nuclides,
-                                                            view)
+                                                            nuclides)
                 std_dev_data = self._create_tally_domain_image(tally,
                                                            'std_dev',
                                                            scores,
-                                                           nuclides,
-                                                           view)
+                                                           nuclides)
                 image_data = 100 * np.divide(std_dev_data[0],
                                              mean_data[0],
                                              out=np.zeros_like(mean_data[0]),
@@ -411,8 +415,7 @@ class PlotModel():
                 image = self._create_tally_domain_image(tally,
                                                         tally_value,
                                                         scores,
-                                                        nuclides,
-                                                        view)
+                                                        nuclides)
                 return image + (units_out,)
 
     def _create_tally_domain_image(self, tally, tally_value, scores, nuclides, view=None):
@@ -501,10 +504,7 @@ class PlotModel():
 
         return image_data, None, data_min, data_max
 
-    def _create_distribcell_image(self, tally, tally_value, scores, nuclides, view=None):
-        if view is None:
-            cv = self.currentView
-
+    def _create_distribcell_image(self, tally, tally_value, scores, nuclides):
         sp = self.statepoint
         dfilter = tally.find_filter(openmc.DistribcellFilter)
 
@@ -529,7 +529,7 @@ class PlotModel():
     def _create_tally_mesh_image(self, tally, tally_value, scores, nuclides, view=None):
         # some variables used throughout
         if view is None:
-            cv = self.currentView
+            view = self.currentView
 
         sp = self.statepoint
         mesh_filter = tally.find_filter(openmc.MeshFilter)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -518,7 +518,7 @@ class PlotModel():
         cell_id_mask = self.cell_ids == cell_id
         for i, v in enumerate(data):
             instance_mask = self.instances == i
-            image_data[np.logical_and(cell_id_mask, instance_mask)] = v
+            image_data[cell_id_mask & instance_mask] = v
 
         data_min = np.min(data)
         data_max = np.max(data)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -505,7 +505,6 @@ class PlotModel():
         return image_data, None, data_min, data_max
 
     def _create_distribcell_image(self, tally, tally_value, scores, nuclides):
-        sp = self.statepoint
         dfilter = tally.find_filter(openmc.DistribcellFilter)
 
         data = tally.get_values(scores=scores, nuclides=nuclides, value=tally_value)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -33,6 +33,7 @@ _ENERGY_UNITS = 'eV per Source Particle'
 _SPATIAL_FILTERS = (openmc.UniverseFilter,
                     openmc.MaterialFilter,
                     openmc.CellFilter,
+                    openmc.DistribcellFilter,
                     openmc.MeshFilter)
 
 _PRODUCTIONS = ('delayed-nu-fission', 'prompt-nu-fission', 'nu-fission',
@@ -280,6 +281,13 @@ class PlotModel():
         self.previousViews.append(copy.deepcopy(self.currentView))
 
     def create_tally_image(self, view=None):
+        """
+        Returns
+        -------
+        tuple : image data (numpy.ndarray), data extents (optional),
+                data_min_value (float), data_max_value (float),
+                data label (str)
+        """
         if view is None:
             view = self.currentView
 
@@ -345,6 +353,32 @@ class PlotModel():
                                                       scores,
                                                       nuclides,
                                                       view)
+                return image + (units_out,)
+        elif tally.contains_filter(openmc.DistribcellFilter):
+            if tally_value == 'rel_err':
+                mean_data = self._create_distribcell_image(tally,
+                                                           'mean',
+                                                           scores,
+                                                           nuclides,
+                                                           view)
+                std_dev_data = self._create_distribcell_image(tally,
+                                                              'std_dev',
+                                                              scores,
+                                                              nuclides,
+                                                              view)
+                image_data = 100 * np.divide(std_dev_data[0],
+                                             mean_data[0],
+                                             out=np.zeros_like(mean_data[0]),
+                                             where=mean_data != 0)
+                data_min = np.min(image_data)
+                data_max = np.max(image_data)
+                return image_data, None, data_min, data_max, '% error'
+            else:
+                image = self._create_distribcell_image(tally,
+                                                       tally_value,
+                                                       scores,
+                                                       nuclides,
+                                                       view)
                 return image + (units_out,)
         else:
             # same as above, get the std. dev. data
@@ -464,6 +498,31 @@ class PlotModel():
 
         # mask out invalid values
         image_data = np.ma.masked_where(data_out < 0.0, data_out)
+
+        return image_data, None, data_min, data_max
+
+    def _create_distribcell_image(self, tally, tally_value, scores, nuclides, view=None):
+        if view is None:
+            cv = self.currentView
+
+        sp = self.statepoint
+        dfilter = tally.find_filter(openmc.DistribcellFilter)
+
+        data = tally.get_values(scores=scores, nuclides=nuclides, value=tally_value)
+        data = data.flatten()
+
+        cell_id = dfilter.bins[0]
+        # create a mask for ids that match the cell
+        image_data = np.zeros_like(self.ids)
+
+        cell_id_mask = self.cell_ids == cell_id
+        for i, v in enumerate(data):
+            instance_mask = self.instances == i
+            image_data[np.logical_and(cell_id_mask, instance_mask)] = v
+
+        data_min = np.min(data)
+        data_max = np.max(data)
+        image_data = np.ma.masked_where(image_data < 0.0, image_data)
 
         return image_data, None, data_min, data_max
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -365,13 +365,11 @@ class PlotModel():
                 mean_data = self._create_distribcell_image(tally,
                                                            'mean',
                                                            scores,
-                                                           nuclides,
-                                                           view)
+                                                           nuclides)
                 std_dev_data = self._create_distribcell_image(tally,
                                                               'std_dev',
                                                               scores,
-                                                              nuclides,
-                                                              view)
+                                                              nuclides)
                 image_data = 100 * np.divide(std_dev_data[0],
                                              mean_data[0],
                                              out=np.zeros_like(mean_data[0]),
@@ -383,8 +381,7 @@ class PlotModel():
                 image = self._create_distribcell_image(tally,
                                                        tally_value,
                                                        scores,
-                                                       nuclides,
-                                                       view)
+                                                       nuclides)
                 return image + (units_out,)
         else:
             # same as above, get the std. dev. data
@@ -512,7 +509,7 @@ class PlotModel():
 
         cell_id = dfilter.bins[0]
         # create a mask for ids that match the cell
-        image_data = np.zeros_like(self.ids)
+        image_data = np.full_like(self.ids, np.nan, dtype=float)
 
         cell_id_mask = self.cell_ids == cell_id
         for i, v in enumerate(data):


### PR DESCRIPTION
@paulromano must have had the same thought that I did in the NEA workshop today and created #86. Plotting these from the Python API is possible, but tricky. This adds that capability to the plotter.