### PR TITLE
Support for CellInstanceFilter

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -406,8 +406,11 @@ class TallyDock(PlotterDock):
                 continue
 
             def _bin_sort_val(bin):
-                if isinstance(bin, Iterable) and all([isinstance(val, float) for val in bin]):
-                    return np.sum(bin)
+                if isinstance(bin, Iterable):
+                    if all([isinstance(val, float) for val in bin]):
+                        return np.sum(bin)
+                    else:
+                        return tuple(bin)
                 else:
                     return bin
 


### PR DESCRIPTION
This PR is a quick follow-up to #87 that extends support to `openmc.CellInstanceFilter` as well. I've managed to do it in a way that requires very little extra code. Technically it makes the logic for distribcell plotting slightly less efficient, but I'm not sure it really matters.

Closes #86