### PR TITLE
Save "Enable Overlap Coloring" settings in edit tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 __pycache__
 plot_settings.pkl
+*.egg-info

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -414,6 +414,7 @@ class MainWindow(QMainWindow):
         self.maskingAction.setChecked(self.model.currentView.masking)
         self.highlightingAct.setChecked(self.model.currentView.highlighting)
         self.outlineAct.setChecked(self.model.currentView.outlines)
+        self.overlapAct.setChecked(self.model.currentView.color_overlaps)
 
         num_previous_views = len(self.model.previousViews)
         self.undoAction.setText('&Undo ({})'.format(num_previous_views))


### PR DESCRIPTION
This saves the "Enable Overlap Coloring" setting state in the edit menu when the plotter is reopened (like the other 3 settings in the menu currently).