### PR TITLE
ignore `plot_settings.pkl` file if model is changed

### DIFF
--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1083,10 +1083,13 @@ class MainWindow(QMainWindow):
                 if (current_mat_xml_hash != model.mat_xml_hash) or \
                     (current_geom_xml_hash != model.geom_xml_hash):
                     # hashes do not match so ignore plot_settings.pkl file
-                    pkl_settings_warn = "WARNING: Model has changed since " +\
-                                        "storing plot settings. Ignoring " +\
-                                        "previous plot settings."
-                    print(pkl_settings_warn)
+                    msg_box = QMessageBox()
+                    msg = "WARNING: Model has changed since storing plot " +\
+                          "settings. Ignoring previous plot settings."
+                    msg_box.setText(msg)
+                    msg_box.setIcon(QMessageBox.Warning)
+                    msg_box.setStandardButtons(QMessageBox.Ok)
+                    msg_box.exec_()
                     return
 
             # do not replace model if the version is out of date

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1068,13 +1068,10 @@ class MainWindow(QMainWindow):
                 model = pickle.load(file)
 
                 # check if loaded cell/mat ids hash match the pkl file:
-                current_mat_hash = hashlib.md5(
-                    pickle.dumps(self.model.mat_ids)).hexdigest()
-                current_cell_hash = hashlib.md5(
-                    pickle.dumps(self.model.cell_ids)).hexdigest()
-
-                if (current_mat_hash != model.mat_ids_hash) or \
-                    (current_cell_hash != model.cell_ids_hash):
+                current_mat_xml_hash = self.hash_file('materials.xml')
+                current_geom_xml_hash = self.hash_file('geometry.xml')
+                if (current_mat_xml_hash != model.mat_xml_hash) or \
+                    (current_geom_xml_hash != model.geom_xml_hash):
                     # hashes do not match so ignore plot_settings.pkl file
                     pkl_settings_warn = "WARNING: Model has changed since " +\
                                         "storing plot settings. Ignoring " +\
@@ -1202,11 +1199,9 @@ class MainWindow(QMainWindow):
         if len(self.model.subsequentViews) > 10:
             self.model.subsequentViews = self.model.subsequentViews[-10:]
 
-        # get hashes for cell/mat ids at close
-        self.model.cell_ids_hash = hashlib.md5(
-            pickle.dumps(self.model.cell_ids)).hexdigest()
-        self.model.mat_ids_hash = hashlib.md5(
-            pickle.dumps(self.model.mat_ids)).hexdigest()
+        # get hashes for geometry.xml and material.xml at close
+        self.model.mat_xml_hash = self.hash_file('materials.xml')
+        self.model.geom_xml_hash = self.hash_file('geometry.xml')
 
         with open('plot_settings.pkl', 'wb') as file:
             if self.model.statepoint:
@@ -1216,3 +1211,15 @@ class MainWindow(QMainWindow):
     def exportTallyData(self):
         # show export tool dialog
         self.showExportDialog()
+
+    @staticmethod
+    def hash_file(filename):
+        # return the md5 hash of a file
+        h = hashlib.md5()
+        with open(filename,'rb') as file:
+            chunk = 0
+            while chunk != b'':
+                # read 1024 bytes at a time
+                chunk = file.read(1024)
+                h.update(chunk)
+        return h.hexdigest()

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -64,7 +64,7 @@ class MainWindow(QMainWindow):
         self.pixmap = None
         self.zoom = 100
 
-        self.loadModel()
+        self.loadModel(use_settings_pkl=use_settings_pkl)
 
         # Create viewing area
         self.frame = QScrollArea(self)
@@ -127,10 +127,6 @@ class MainWindow(QMainWindow):
         QtCore.QTimer.singleShot(0, self.showCurrentView)
 
         self.plotIm.frozen = False
-
-        # restore plot settings after loading materials/cells
-        if use_settings_pkl:
-            self.restoreModelSettings()
 
     def event(self, event):
         # use pinch event to update zoom
@@ -460,12 +456,15 @@ class MainWindow(QMainWindow):
         self.mainWindowAction.setChecked(self.isActiveWindow())
 
     # Menu and shared methods
-    def loadModel(self, reload=False):
+    def loadModel(self, reload=False, use_settings_pkl=True):
         if reload:
             self.resetModels()
         else:
             # create new plot model
             self.model = PlotModel()
+            if use_settings_pkl:
+                self.restoreModelSettings()
+            # update plot and model settings
             self.updateRelativeBases()
 
         self.cellsModel = DomainTableModel(self.model.activeView.cells)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -38,6 +38,17 @@ def _openmcReload():
     openmc.lib.init(["-c"])
     openmc.lib.settings.verbosity = 1
 
+def hash_file(filename):
+    # return the md5 hash of a file
+    h = hashlib.md5()
+    with open(filename,'rb') as file:
+        chunk = 0
+        while chunk != b'':
+            # read 32768 bytes at a time
+            chunk = file.read(32768)
+            h.update(chunk)
+    return h.hexdigest()
+
 class MainWindow(QMainWindow):
     def __init__(self,
                  font=QtGui.QFontMetrics(QtGui.QFont()),
@@ -1068,8 +1079,8 @@ class MainWindow(QMainWindow):
                 model = pickle.load(file)
 
                 # check if loaded cell/mat ids hash match the pkl file:
-                current_mat_xml_hash = self.hash_file('materials.xml')
-                current_geom_xml_hash = self.hash_file('geometry.xml')
+                current_mat_xml_hash = hash_file('materials.xml')
+                current_geom_xml_hash = hash_file('geometry.xml')
                 if (current_mat_xml_hash != model.mat_xml_hash) or \
                     (current_geom_xml_hash != model.geom_xml_hash):
                     # hashes do not match so ignore plot_settings.pkl file
@@ -1200,8 +1211,8 @@ class MainWindow(QMainWindow):
             self.model.subsequentViews = self.model.subsequentViews[-10:]
 
         # get hashes for geometry.xml and material.xml at close
-        self.model.mat_xml_hash = self.hash_file('materials.xml')
-        self.model.geom_xml_hash = self.hash_file('geometry.xml')
+        self.model.mat_xml_hash = hash_file('materials.xml')
+        self.model.geom_xml_hash = hash_file('geometry.xml')
 
         with open('plot_settings.pkl', 'wb') as file:
             if self.model.statepoint:
@@ -1212,14 +1223,3 @@ class MainWindow(QMainWindow):
         # show export tool dialog
         self.showExportDialog()
 
-    @staticmethod
-    def hash_file(filename):
-        # return the md5 hash of a file
-        h = hashlib.md5()
-        with open(filename,'rb') as file:
-            chunk = 0
-            while chunk != b'':
-                # read 1024 bytes at a time
-                chunk = file.read(1024)
-                h.update(chunk)
-        return h.hexdigest()


### PR DESCRIPTION
closes #77 

If either the materials IDs or cell IDs are altered between when the GUI was last closed and when it is reopened with the `plot_settings.pkl` file, this will ignore the settings file (previously this would cause an error). 

In order for this to work, `restoreModelSettings()` has to be called after the cell and material IDs have been populated in the model (ie, after the plot model is no longer "frozen"). 

Are there any other properties/model changes that could cause these errors that are not captured in cell IDs and mat IDs?