### PR TITLE
Adding option to set number of threads when opening the plotter

### DIFF
--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -19,7 +19,7 @@ def main():
     ap.add_argument('-e','--ignore-settings', action='store_false',
                     help='Ignore plot_settings.pkl file if present.')
     ap.add_argument('-s', '--threads', type=int, default=None,
-                    help='If present, number of threads used to generate plots')
+                    help='If present, number of threads used to generate plots.')
 
     args = ap.parse_args()
 

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -19,7 +19,7 @@ def main():
     ap.add_argument('-e','--ignore-settings', action='store_false',
                     help='Ignore plot_settings.pkl file if present.')
     ap.add_argument('-s', '--threads', type=int, default=None,
-                    help='If present, number of threads used to run OpenMC')
+                    help='If present, number of threads used to generate plots')
 
     args = ap.parse_args()
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -28,13 +28,16 @@ from .tools import ExportDataDialog
 
 _COORD_LEVELS = 0
 
-def _openmcReload():
+def _openmcReload(threads=None):
     # reset OpenMC memory, instances
     openmc.lib.reset()
     openmc.lib.finalize()
     # initialize geometry (for volume calculation)
     openmc.lib.settings.output_summary = False
-    openmc.lib.init(["-c"])
+    args = ["-c"]
+    if threads is not None:
+        args += ["-s", str(threads)]
+    openmc.lib.init(args)
     openmc.lib.settings.verbosity = 1
 
 class MainWindow(QMainWindow):


### PR DESCRIPTION
Adding an option to set the number of threads OpenMC will use when starting the plotter. Got tired of having to set and reset `OMP_NUM_THREADS` to do this. Used the same CML flags as the `openmc` executable for consistency.