### PR TITLE
Separate model view from view settings for more reliable reload

### DIFF
--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     _HAVE_VTK = False
 
-from .plotmodel import PlotModel, DomainTableModel, PlotView
+from .plotmodel import PlotModel, DomainTableModel
 from .plotgui import PlotImage, ColorDialog
 from .docks import DomainDock, TallyDock
 from .overlays import ShortcutsOverlay

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -3,7 +3,6 @@ from functools import partial
 import os
 import pickle
 from threading import Thread
-import hashlib
 
 from PySide2 import QtCore, QtGui
 from PySide2.QtGui import QKeyEvent
@@ -21,7 +20,7 @@ try:
 except ImportError:
     _HAVE_VTK = False
 
-from .plotmodel import PlotModel, DomainTableModel
+from .plotmodel import PlotModel, DomainTableModel, hash_file
 from .plotgui import PlotImage, ColorDialog
 from .docks import DomainDock, TallyDock
 from .overlays import ShortcutsOverlay
@@ -1154,10 +1153,16 @@ class MainWindow(QMainWindow):
         if self.model.statepoint:
                 self.model.statepoint.close()
 
+        # get hashes for geometry.xml and material.xml at close
+        mat_xml_hash = hash_file('materials.xml')
+        geom_xml_hash = hash_file('geometry.xml')
+
         pickle_data = {
             'version': self.model.version,
             'currentView': self.model.currentView,
-            'statepoint': self.model.statepoint
+            'statepoint': self.model.statepoint,
+            'mat_xml_hash': mat_xml_hash,
+            'geom_xml_hash': geom_xml_hash
         }
         with open('plot_settings.pkl', 'wb') as file:
             pickle.dump(pickle_data, file)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1151,16 +1151,16 @@ class MainWindow(QMainWindow):
         self.saveSettings()
 
     def saveSettings(self):
-
-        if len(self.model.previousViews) > 10:
-            self.model.previousViews = self.model.previousViews[-10:]
-        if len(self.model.subsequentViews) > 10:
-            self.model.subsequentViews = self.model.subsequentViews[-10:]
-
-        with open('plot_settings.pkl', 'wb') as file:
-            if self.model.statepoint:
+        if self.model.statepoint:
                 self.model.statepoint.close()
-            pickle.dump(self.model, file)
+
+        pickle_data = {
+            'version': self.model.version,
+            'currentView_ind': self.model.currentView.view_ind,
+            'statepoint': self.model.statepoint
+        }
+        with open('plot_settings.pkl', 'wb') as file:
+            pickle.dump(pickle_data, file)
 
     def exportTallyData(self):
         # show export tool dialog

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -119,8 +119,6 @@ class MainWindow(QMainWindow):
         QtCore.QTimer.singleShot(0, self.showCurrentView)
 
         self.plotIm.frozen = False
-        #print(dir(self.model))
-
 
     def event(self, event):
         # use pinch event to update zoom

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1156,7 +1156,7 @@ class MainWindow(QMainWindow):
 
         pickle_data = {
             'version': self.model.version,
-            'currentView_ind': self.model.currentView.view_ind,
+            'currentView': self.model.currentView,
             'statepoint': self.model.statepoint
         }
         with open('plot_settings.pkl', 'wb') as file:

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -130,10 +130,20 @@ class PlotModel():
         self.subsequentViews = []
 
         if use_settings_pkl and os.path.isfile('plot_settings.pkl'):
-            try:
-                with open('plot_settings.pkl', 'rb') as file:
+            with open('plot_settings.pkl', 'rb') as file:
+                try:
                     data = pickle.load(file)
+                except AttributeError:
+                    msg_box = QMessageBox()
+                    msg = "WARNING: previous plot settings are in an incompatible format. " +\
+                          "They will be ignored."
+                    msg_box.setText(msg)
+                    msg_box.setIcon(QMessageBox.Warning)
+                    msg_box.setStandardButtons(QMessageBox.Ok)
+                    msg_box.exec_()
+                    self.defaultView = self.getDefaultView()
 
+                else:
                     # check GUI version
                     if data['version'] != self.version:
                         print("WARNING: previous plot settings are for a different "
@@ -157,15 +167,7 @@ class PlotModel():
                             self.statepoint = None
 
                     self.defaultView = PlotView(restore_view=view_ind)
-            except AttributeError:
-                msg_box = QMessageBox()
-                msg = "WARNING: previous plot settings are in an incompatible format. " +\
-                      "They will be ignored."
-                msg_box.setText(msg)
-                msg_box.setIcon(QMessageBox.Warning)
-                msg_box.setStandardButtons(QMessageBox.Ok)
-                msg_box.exec_()
-                self.defaultView = self.getDefaultView()
+
         else:
             self.defaultView = self.getDefaultView()
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -73,6 +73,10 @@ class PlotModel():
             Dictionary mapping material IDs to openmc.Material instances
         ids : NumPy int array (v_res, h_res, 1)
             Mapping of plot coordinates to cell/material ID by pixel
+        ids_map : NumPy int32 array (v_res, h_res, 3)
+            Mapping of cell and material ids
+        props_map : Numpy float array (v_res, h_res, 3)
+            Mapping of cell temperatures and material densities
         image : NumPy int array (v_res, h_res, 3)
             The current RGB image data
         statepoint : StatePointModel
@@ -107,8 +111,8 @@ class PlotModel():
         self.instances = None
 
         # ID and Props (curren)
-        self.__ids_map = None
-        self.__props_map = None
+        self.ids_map = None
+        self.props_map = None
 
         self.version = __VERSION__
 
@@ -242,16 +246,16 @@ class PlotModel():
         cv = self.currentView = copy.deepcopy(self.activeView)
         pv = self.previousViews[-1]
 
-        if (self.__props_map is None) or (self.__ids_map is None) or \
+        if (self.props_map is None) or (self.ids_map is None) or \
             (cv.view_params != pv.view_params):
             # we are at the first view and need to populate OR
             # view has changed and need to populate
-            self.__ids_map = openmc.lib.id_map(cv.view_params)
-            self.__props_map = openmc.lib.property_map(cv.view_params)
+            self.ids_map = openmc.lib.id_map(cv.view_params)
+            self.props_map = openmc.lib.property_map(cv.view_params)
 
-        self.cell_ids = self.__ids_map[:, :, 0]
-        self.instances = self.__ids_map[:, :, 1]
-        self.mat_ids = self.__ids_map[:, :, 2]
+        self.cell_ids = self.ids_map[:, :, 0]
+        self.instances = self.ids_map[:, :, 1]
+        self.mat_ids = self.ids_map[:, :, 2]
 
         # set model ids based on domain
         if cv.colorby == 'cell':
@@ -292,7 +296,7 @@ class PlotModel():
         # set model image
         self.image = image
         # set model properties
-        self.properties = self.__props_map
+        self.properties = self.props_map
         # tally data
         self.tally_data = None
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -739,12 +739,9 @@ class ViewParam(openmc.lib.plot._PlotBase):
         self.color_overlaps = False
 
     def __eq__(self, other):
-        if repr(self) == repr(other):
-            return True
-        else:
-            return False
+        return repr(self) == repr(other)
 
-class PlotViewIndependent():
+class PlotViewIndependent:
     """View settings for OpenMC plot, independent of the model.
 
     Attributes
@@ -899,7 +896,7 @@ class PlotViewIndependent():
         self.v_res = self.v_res
         self.basis = view.basis
 
-class PlotView():
+class PlotView:
     """Setup the view of the model.
 
     Parameters

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -1,7 +1,6 @@
 from ast import literal_eval
 from collections import defaultdict
 import copy
-from curses import resize_term
 import itertools
 import threading
 import os

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -944,6 +944,10 @@ class PlotView:
         Label of the currently selected tally
     """
 
+    attrs = ('view_ind', 'view_params', 'cells', 'materials', 'selectedTally')
+    plotbase_attrs = ('level', 'origin', 'width', 'height',
+                      'h_res', 'v_res', 'basis', 'color_overlaps')
+
     def __init__(self, origin=(0, 0, 0), width=10, height=10, restore_view=None):
         """Initialize PlotView attributes"""
 
@@ -960,21 +964,19 @@ class PlotView:
         self.selectedTally = None
 
     def __getattr__(self, name):
-        if name in ['view_ind', 'view_params', 'cells', 'materials', 'selectedTally']:
+        if name in self.attrs:
             if name not in self.__dict__:
                 raise AttributeError('{} not in PlotView dict'.format(name))
             return self.__dict__[name]
-        elif name in ['level', 'origin', 'width', 'height',
-                      'h_res', 'v_res', 'basis', 'color_overlaps']:
+        elif name in self.plotbase_attrs:
             return getattr(self.view_params, name)
         else:
             return getattr(self.view_ind, name)
 
     def __setattr__(self, name, value):
-        if name in ['view_ind', 'view_params', 'cells', 'materials', 'selectedTally']:
+        if name in self.attrs:
             super().__setattr__(name, value)
-        elif name in ['level', 'origin', 'width', 'height',
-                      'h_res', 'v_res', 'basis', 'color_overlaps']:
+        elif name in self.plotbase_attrs:
             setattr(self.view_params, name, value)
         else:
             setattr(self.view_ind, name, value)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -1,7 +1,6 @@
 from ast import literal_eval
 from collections import defaultdict
 import copy
-from difflib import restore
 import itertools
 import threading
 import os

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -748,24 +748,10 @@ class ViewParam(openmc.lib.plot._PlotBase):
         self.color_overlaps = False
 
     def __eq__(self, other):
-        if (isinstance(other, ViewParam)):
-            for name in ['level', 'origin', 'width', 'height', 'h_res',
-                         'v_res', 'basis', 'color_overlaps']:
-                if self.__getattr__(name) != other.__getattr__(name):
-                    return False
+        if repr(self) == repr(other):
             return True
         else:
             return False
-
-    def __getattr__(self, name):
-        if name not in self.__dict__:
-            raise AttributeError('{} not in ViewParam dict'.format(name))
-        return self.__dict__[name]
-
-    def __setattr__(self, name, value):
-        super().__setattr__(name, value)
-        self.__dict__[name] = value
-
 
 class PlotViewIndependent():
     """View settings for OpenMC plot, independent of the model.
@@ -837,10 +823,8 @@ class PlotViewIndependent():
         Number of contours levels or explicit level values
     """
 
-    def __init__(self, origin=(0, 0, 0), width=10, height=10):
+    def __init__(self):
         """Initialize PlotViewIndependent attributes"""
-        self.view_params = ViewParam(origin=origin, width=width, height=height)
-
         # Geometry Plot
         self.aspectLock = True
         self.colorby = 'material'
@@ -877,21 +861,6 @@ class PlotViewIndependent():
         self.tallyValue = "Mean"
         self.tallyContours = False
         self.tallyContourLevels = ""
-
-    def __getattr__(self, name):
-        if name in ['level', 'origin', 'width', 'height',
-                    'h_res', 'v_res', 'basis', 'color_overlaps']:
-            return getattr(self.view_params, name)
-        if name not in self.__dict__:
-            raise AttributeError('{} not in PlotViewIndependent dict'.format(name))
-        return self.__dict__[name]
-
-    def __setattr__(self, name, value):
-        if name in ['level', 'origin', 'width', 'height',
-                    'h_res', 'v_res', 'basis', 'color_overlaps']:
-            setattr(self.view_params, name, value)
-        else:
-            super().__setattr__(name, value)
 
     def getDataLimits(self):
         return self.data_minmax
@@ -969,7 +938,9 @@ class PlotView():
         if restore_view is not None:
             self.view_ind = copy.copy(restore_view)
         else:
-            self.view_ind = PlotViewIndependent(origin=origin, width=width, height=height)
+            self.view_ind = PlotViewIndependent()
+
+        self.view_params = ViewParam(origin=origin, width=width, height=height)
 
         # Get model domain info
         self.cells = self.getDomains('cell')
@@ -981,11 +952,18 @@ class PlotView():
             if name not in self.__dict__:
                 raise AttributeError('{} not in PlotView dict'.format(name))
             return self.__dict__[name]
-        return getattr(self.view_ind, name)
+        elif name in ['level', 'origin', 'width', 'height',
+                      'h_res', 'v_res', 'basis', 'color_overlaps']:
+            return getattr(self.view_params, name)
+        else:
+            return getattr(self.view_ind, name)
 
     def __setattr__(self, name, value):
         if name in ['view_ind', 'cells', 'materials', 'selectedTally']:
             super().__setattr__(name, value)
+        elif name in ['level', 'origin', 'width', 'height',
+                      'h_res', 'v_res', 'basis', 'color_overlaps']:
+            setattr(self.view_params, name, value)
         else:
             setattr(self.view_ind, name, value)
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -684,7 +684,7 @@ class PlotModel():
 
 
 class PlotViewIndependent(openmc.lib.plot._PlotBase):
-    """ View settings for OpenMC plot, independent of the model.
+    """View settings for OpenMC plot, independent of the model.
 
     Parameters
     ----------
@@ -694,6 +694,8 @@ class PlotViewIndependent(openmc.lib.plot._PlotBase):
         Width of plot view in model units
     height : float
         Height of plot view in model units
+    restore_view : PlotView or PlotViewIndependent or None
+        view object with specified parameters to restore
 
     Attributes
     ----------
@@ -770,6 +772,8 @@ class PlotViewIndependent(openmc.lib.plot._PlotBase):
         super().__init__()
 
         if restore_view is not None:
+            # set parameters based on supplied view
+
             # View Parameters
             self.level = restore_view.level
             self.origin = restore_view.origin
@@ -818,6 +822,7 @@ class PlotViewIndependent(openmc.lib.plot._PlotBase):
 
         else:
             # set defaults
+
             # View Parameters
             self.level = -1
             self.origin = origin
@@ -922,7 +927,7 @@ class PlotViewIndependent(openmc.lib.plot._PlotBase):
         self.basis = view.basis
 
 class PlotView(PlotViewIndependent):
-    """ View settings for OpenMC plot.
+    """Setup the view of the model.
 
     Attributes
     ----------

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -110,7 +110,7 @@ class PlotModel():
         self.ids = None
         self.instances = None
 
-        # ID and Props (curren)
+        # Return values from id_map and property_map
         self.ids_map = None
         self.props_map = None
 
@@ -159,7 +159,7 @@ class PlotModel():
                     self.defaultView = PlotView(restore_view=view_ind)
             except AttributeError:
                 msg_box = QMessageBox()
-                msg = "WARNING: previous plot settings are incorrect format. " +\
+                msg = "WARNING: previous plot settings are in an incompatible format. " +\
                       "They will be ignored."
                 msg_box.setText(msg)
                 msg_box.setIcon(QMessageBox.Warning)
@@ -916,7 +916,7 @@ class PlotView:
     ----------
     origin : 3-tuple of floats
         Origin (center) of plot view
-    width: float
+    width : float
         Width of plot view in model units
     height : float
         Height of plot view in model units

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -155,9 +155,9 @@ class PlotModel():
                             "version of the GUI. They will be ignored.")
                         wrn_msg = "Existing version: {}, Current GUI version: {}"
                         print(wrn_msg.format(data['version'], self.version))
-                        view_ind = None
+                        view = None
                     else:
-                        view_ind = data['currentView_ind']
+                        view = data['currentView']
 
                         # restore statepoint file
                         try:
@@ -171,7 +171,7 @@ class PlotModel():
                             msg_box.exec_()
                             self.statepoint = None
 
-                    self.defaultView = PlotView(restore_view=view_ind)
+                    self.defaultView = PlotView(restore_view=view)
 
         else:
             self.defaultView = self.getDefaultView()
@@ -927,7 +927,7 @@ class PlotView:
         Width of plot view in model units
     height : float
         Height of plot view in model units
-    restore_view : PlotView or PlotViewIndependent or None
+    restore_view : PlotView or None
         view object with specified parameters to restore
 
     Attributes
@@ -948,7 +948,7 @@ class PlotView:
         """Initialize PlotView attributes"""
 
         if restore_view is not None:
-            self.view_ind = copy.copy(restore_view)
+            self.view_ind = copy.copy(restore_view.view_ind)
             self.view_params = copy.copy(restore_view.view_params)
         else:
             self.view_ind = PlotViewIndependent()

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -91,7 +91,7 @@ class PlotModel():
             Mapping of plot coordinates to cell/material ID by pixel
         ids_map : NumPy int32 array (v_res, h_res, 3)
             Mapping of cell and material ids
-        props_map : Numpy float array (v_res, h_res, 3)
+        properties : Numpy float array (v_res, h_res, 3)
             Mapping of cell temperatures and material densities
         image : NumPy int array (v_res, h_res, 3)
             The current RGB image data
@@ -128,7 +128,7 @@ class PlotModel():
 
         # Return values from id_map and property_map
         self.ids_map = None
-        self.props_map = None
+        self.properties = None
 
         self.version = __VERSION__
 
@@ -275,12 +275,12 @@ class PlotModel():
         cv = self.currentView = copy.deepcopy(self.activeView)
         pv = self.previousViews[-1]
 
-        if (self.props_map is None) or (self.ids_map is None) or \
+        if (self.properties is None) or (self.ids_map is None) or \
             (cv.view_params != pv.view_params):
             # we are at the first view and need to populate OR
             # view has changed and need to populate
             self.ids_map = openmc.lib.id_map(cv.view_params)
-            self.props_map = openmc.lib.property_map(cv.view_params)
+            self.properties = openmc.lib.property_map(cv.view_params)
 
         self.cell_ids = self.ids_map[:, :, 0]
         self.instances = self.ids_map[:, :, 1]
@@ -324,8 +324,7 @@ class PlotModel():
 
         # set model image
         self.image = image
-        # set model properties
-        self.properties = self.props_map
+
         # tally data
         self.tally_data = None
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -127,32 +127,42 @@ class PlotModel():
         self.subsequentViews = []
 
         if use_settings_pkl and os.path.isfile('plot_settings.pkl'):
-            with open('plot_settings.pkl', 'rb') as file:
-                data = pickle.load(file)
+            try:
+                with open('plot_settings.pkl', 'rb') as file:
+                    data = pickle.load(file)
 
-                # check GUI version
-                if data['version'] != self.version:
-                    print("WARNING: previous plot settings are for a different "
-                        "version of the GUI. They will be ignored.")
-                    wrn_msg = "Existing version: {}, Current GUI version: {}"
-                    print(wrn_msg.format(data['version'], self.version))
-                    view_ind = None
-                else:
-                    view_ind = data['currentView_ind']
+                    # check GUI version
+                    if data['version'] != self.version:
+                        print("WARNING: previous plot settings are for a different "
+                            "version of the GUI. They will be ignored.")
+                        wrn_msg = "Existing version: {}, Current GUI version: {}"
+                        print(wrn_msg.format(data['version'], self.version))
+                        view_ind = None
+                    else:
+                        view_ind = data['currentView_ind']
 
-                    # restore statepoint file
-                    try:
-                        self.statepoint = data['statepoint']
-                    except OSError:
-                        msg_box = QMessageBox()
-                        msg = "Could not open statepoint file: \n\n {} \n"
-                        msg_box.setText(msg.format(self.model.statepoint.filename))
-                        msg_box.setIcon(QMessageBox.Warning)
-                        msg_box.setStandardButtons(QMessageBox.Ok)
-                        msg_box.exec_()
-                        self.statepoint = None
+                        # restore statepoint file
+                        try:
+                            self.statepoint = data['statepoint']
+                        except OSError:
+                            msg_box = QMessageBox()
+                            msg = "Could not open statepoint file: \n\n {} \n"
+                            msg_box.setText(msg.format(self.model.statepoint.filename))
+                            msg_box.setIcon(QMessageBox.Warning)
+                            msg_box.setStandardButtons(QMessageBox.Ok)
+                            msg_box.exec_()
+                            self.statepoint = None
 
-                self.defaultView = PlotView(restore_view=view_ind)
+                    self.defaultView = PlotView(restore_view=view_ind)
+            except AttributeError:
+                msg_box = QMessageBox()
+                msg = "WARNING: previous plot settings are incorrect format. " +\
+                      "will be ignored."
+                msg_box.setText(msg)
+                msg_box.setIcon(QMessageBox.Warning)
+                msg_box.setStandardButtons(QMessageBox.Ok)
+                msg_box.exec_()
+                self.defaultView = self.getDefaultView()
         else:
             self.defaultView = self.getDefaultView()
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -231,23 +231,14 @@ class PlotModel():
         Runs OpenMC in plot mode to generate new plot image.
         """
         cv = self.currentView = copy.deepcopy(self.activeView)
-        pv = self.previousViews[-1]  # pv will always be at least 1 to store current views, so only do this if len > 1
+        pv = self.previousViews[-1]
 
-        print('*** NEW CALL TO MAKEPLOT ***')
-        print(cv.view_params == pv.view_params)
-        print('Previous View Parameters')
-        print(pv.view_params)
-        print('Current View Parameters')
-        print(cv.view_params)
-
-        if (self.__props_map is None) or (self.__ids_map is None) or (cv.view_params != pv.view_params):
-            print('generating new id/prop map')
-            # we are at the first view and need to populate OR view has changed and need to populate
+        if (self.__props_map is None) or (self.__ids_map is None) or \
+            (cv.view_params != pv.view_params):
+            # we are at the first view and need to populate OR
+            # view has changed and need to populate
             self.__ids_map = openmc.lib.id_map(cv.view_params)
             self.__props_map = openmc.lib.property_map(cv.view_params)
-
-        else:
-            print('no change')
 
         self.cell_ids = self.__ids_map[:, :, 0]
         self.instances = self.__ids_map[:, :, 1]

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -928,10 +928,10 @@ class PlotView():
 
         if restore_view is not None:
             self.view_ind = copy.copy(restore_view)
+            self.view_params = copy.copy(restore_view.view_params)
         else:
             self.view_ind = PlotViewIndependent()
-
-        self.view_params = ViewParam(origin=origin, width=width, height=height)
+            self.view_params = ViewParam(origin=origin, width=width, height=height)
 
         # Get model domain info
         self.cells = self.getDomains('cell')

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -71,6 +71,8 @@ def hash_file(filename):
             chunk = file.read(32768)
             h.update(chunk)
     return h.hexdigest()
+
+
 class PlotModel():
     """ Geometry and plot settings for OpenMC Plot Explorer model
 
@@ -272,15 +274,17 @@ class PlotModel():
         Creates corresponding .xml files from user-chosen settings.
         Runs OpenMC in plot mode to generate new plot image.
         """
-        cv = self.currentView = copy.deepcopy(self.activeView)
-        pv = self.previousViews[-1]
+        # update/call maps under 2 circumstances
+        #   1. this is the intial plot (ids_map/properties are None)
+        #   2. The active (desired) view differs from the current view parameters
+        if (self.currentView.view_params != self.activeView.view_params) or \
+            (self.ids_map is None) or (self.properties is None):
+            # get ids from the active (desired) view
+            self.ids_map = openmc.lib.id_map(self.activeView.view_params)
+            self.properties = openmc.lib.property_map(self.activeView.view_params)
 
-        if (self.properties is None) or (self.ids_map is None) or \
-            (cv.view_params != pv.view_params):
-            # we are at the first view and need to populate OR
-            # view has changed and need to populate
-            self.ids_map = openmc.lib.id_map(cv.view_params)
-            self.properties = openmc.lib.property_map(cv.view_params)
+        # update current view
+        cv = self.currentView = copy.deepcopy(self.activeView)
 
         # set model ids based on domain
         if cv.colorby == 'cell':

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -128,21 +128,21 @@ class PlotModel():
 
         if use_settings_pkl and os.path.isfile('plot_settings.pkl'):
             with open('plot_settings.pkl', 'rb') as file:
-                model = pickle.load(file)
+                data = pickle.load(file)
 
                 # check GUI version
-                if model.version != self.version:
+                if data['version'] != self.version:
                     print("WARNING: previous plot settings are for a different "
                         "version of the GUI. They will be ignored.")
                     wrn_msg = "Existing version: {}, Current GUI version: {}"
-                    print(wrn_msg.format(model.version, self.version))
-                    view = None
+                    print(wrn_msg.format(data['version'], self.version))
+                    view_ind = None
                 else:
-                    view = model.currentView
+                    view_ind = data['currentView_ind']
 
                     # restore statepoint file
                     try:
-                        self.statepoint = model.statepoint
+                        self.statepoint = data['statepoint']
                     except OSError:
                         msg_box = QMessageBox()
                         msg = "Could not open statepoint file: \n\n {} \n"
@@ -152,7 +152,7 @@ class PlotModel():
                         msg_box.exec_()
                         self.statepoint = None
 
-                self.defaultView = PlotView(restore_view=view.view_ind)
+                self.defaultView = PlotView(restore_view=view_ind)
         else:
             self.defaultView = self.getDefaultView()
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -144,6 +144,8 @@ class PlotModel():
         self.previousViews = []
         self.subsequentViews = []
 
+        self.defaultView = self.getDefaultView()
+
         if use_settings_pkl and os.path.isfile('plot_settings.pkl'):
             with open('plot_settings.pkl', 'rb') as file:
                 try:
@@ -156,7 +158,7 @@ class PlotModel():
                     msg_box.setIcon(QMessageBox.Warning)
                     msg_box.setStandardButtons(QMessageBox.Ok)
                     msg_box.exec_()
-                    self.defaultView = self.getDefaultView()
+                    self.currentView = copy.deepcopy(self.defaultView)
 
                 else:
                     restore_domains = False
@@ -191,14 +193,13 @@ class PlotModel():
                             msg_box.exec_()
                             self.statepoint = None
 
-                    self.defaultView = PlotView(restore_view=view,
+                    self.currentView = PlotView(restore_view=view,
                                                 restore_domains=restore_domains)
 
         else:
-            self.defaultView = self.getDefaultView()
+            self.currentView = copy.deepcopy(self.defaultView)
 
-        self.currentView = copy.deepcopy(self.defaultView)
-        self.activeView = copy.deepcopy(self.defaultView)
+        self.activeView = copy.deepcopy(self.currentView)
 
     def openStatePoint(self, filename):
         self.statepoint = StatePointModel(filename, open_file=True)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -157,7 +157,7 @@ class PlotModel():
             except AttributeError:
                 msg_box = QMessageBox()
                 msg = "WARNING: previous plot settings are incorrect format. " +\
-                      "will be ignored."
+                      "They will be ignored."
                 msg_box.setText(msg)
                 msg_box.setIcon(QMessageBox.Warning)
                 msg_box.setStandardButtons(QMessageBox.Ok)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -920,22 +920,6 @@ class PlotViewIndependent:
             z = self.origin[2] + self.height / 2.0
         return x, y, z
 
-    def adopt_plotbase(self, view):
-        """
-        Applies only the geometric aspects of a view to the current view
-
-        Parameters
-        ----------
-
-        view : PlotView
-            View to take parameters from
-        """
-        self.origin = view.origin
-        self.width = view.width
-        self.height = view.height
-        self.h_res = self.h_res
-        self.v_res = self.v_res
-        self.basis = view.basis
 
 class PlotView:
     """Setup the view of the model.
@@ -1056,6 +1040,23 @@ class PlotView:
                                           False)
 
         return domains
+
+    def adopt_plotbase(self, view):
+        """
+        Applies only the geometric aspects of a view to the current view
+
+        Parameters
+        ----------
+
+        view : PlotView
+            View to take parameters from
+        """
+        self.origin = view.origin
+        self.width = view.width
+        self.height = view.height
+        self.h_res = view.h_res
+        self.v_res = view.v_res
+        self.basis = view.basis
 
 
 class DomainView():

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -63,6 +63,11 @@ _TALLY_VALUES = {'Mean': 'mean',
 class PlotModel():
     """ Geometry and plot settings for OpenMC Plot Explorer model
 
+        Parameters
+        ----------
+        use_settings_pkl : bool
+            If True, use plot_settings.pkl file to reload settings
+
         Attributes
         ----------
         geom : openmc.Geometry instance

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -18,7 +18,7 @@ from .plot_colors import random_rgb, reset_seed
 
 ID, NAME, COLOR, COLORLABEL, MASK, HIGHLIGHT = tuple(range(0, 6))
 
-__VERSION__ = "0.2.1"
+__VERSION__ = "0.2.2"
 
 _VOID_REGION = -1
 _NOT_FOUND = -2

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -701,8 +701,42 @@ class PlotModel():
         return image_data, extents, data_min, data_max
 
 class ViewParam(openmc.lib.plot._PlotBase):
+    """Viewer settings that are needed for _PlotBase and are independent
+    of all other plotter/model settings.
+
+    Parameters
+    ----------
+    origin : 3-tuple of floats
+        Origin (center) of plot view
+    width: float
+        Width of plot view in model units
+    height : float
+        Height of plot view in model units
+
+    Attributes
+    ----------
+    origin : 3-tuple of floats
+        Origin (center) of plot view
+    width : float
+        Width of the plot view in model units
+    height : float
+        Height of the plot view in model units
+    h_res : int
+        Horizontal resolution of plot image
+    v_res : int
+        Vertical resolution of plot image
+    basis : {'xy', 'xz', 'yz'}
+        The basis directions for the plot
+    color_overlaps : bool
+        Indicator of whether or not overlaps will be shown
+    level : int
+        The universe level for the plot (default: -1 -> all universes shown)
+    """
+
     def __init__(self, origin=(0, 0, 0), width=10, height=10):
+        """Initialize ViewParam attributes"""
         super().__init__()
+
         # View Parameters
         self.level = -1
         self.origin = origin
@@ -749,21 +783,9 @@ class PlotViewIndependent():
 
     Attributes
     ----------
-    origin : 3-tuple of floats
-        Origin (center) of plot view
-    width : float
-        Width of the plot view in model units
-    height : float
-        Height of the plot view in model units
-    h_res : int
-        Horizontal resolution of plot image
-    v_res : int
-        Vertical resolution of plot image
     aspectLock : bool
         Indication of whether aspect lock should be maintained to
         prevent image stretching/warping
-    basis : {'xy', 'xz', 'yz'}
-        The basis directions for the plot
     colorby : {'cell', 'material', 'temperature', 'density'}
         Indication of whether the plot should be colored by cell or material
     masking : bool
@@ -781,8 +803,6 @@ class PlotViewIndependent():
         is active
     domainBackground : 3-tuple of int
         RGB color to apply to plot background
-    color_overlaps : bool
-        Indicator of whether or not overlaps will be shown
     overlap_color : 3-tuple of int
         RGB color to apply for cell overlap regions
     domainAlpha : float between 0 and 1
@@ -816,27 +836,13 @@ class PlotViewIndependent():
     tallyContourLevels : str
         Number of contours levels or explicit level values
     """
+
     def __init__(self, origin=(0, 0, 0), width=10, height=10):
-        """ Initialize PlotView attributes """
-
-
+        """Initialize PlotViewIndependent attributes"""
         self.view_params = ViewParam(origin=origin, width=width, height=height)
 
-        # set defaults
-        """
-        # View Parameters
-        self.level = -1
-        self.origin = origin
-        self.width = width
-        self.height = height
-        self.h_res = 1000
-        self.v_res = 1000
-        self.basis = 'xy'
-        self.aspectLock = True
-        """
-        self.aspectLock = True
-
         # Geometry Plot
+        self.aspectLock = True
         self.colorby = 'material'
         self.masking = True
         self.maskBackground = (0, 0, 0)
@@ -958,7 +964,7 @@ class PlotView():
     """
 
     def __init__(self, origin=(0, 0, 0), width=10, height=10, restore_view=None):
-        """ Initialize PlotView attributes """
+        """Initialize PlotView attributes"""
 
         if restore_view is not None:
             self.view_ind = copy.copy(restore_view)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -124,7 +124,6 @@ class PlotModel():
 
         # Cell/Material ID by coordinates
         self.ids = None
-        self.instances = None
 
         # Return values from id_map and property_map
         self.ids_map = None
@@ -281,10 +280,6 @@ class PlotModel():
             # view has changed and need to populate
             self.ids_map = openmc.lib.id_map(cv.view_params)
             self.properties = openmc.lib.property_map(cv.view_params)
-
-        self.cell_ids = self.ids_map[:, :, 0]
-        self.instances = self.ids_map[:, :, 1]
-        self.mat_ids = self.ids_map[:, :, 2]
 
         # set model ids based on domain
         if cv.colorby == 'cell':
@@ -731,6 +726,19 @@ class PlotModel():
                    lower_left[v_ind], upper_right[v_ind]]
 
         return image_data, extents, data_min, data_max
+
+    @property
+    def cell_ids(self):
+        return self.ids_map[:, :, 0]
+
+    @property
+    def instances(self):
+        return self.ids_map[:, :, 1]
+
+    @property
+    def mat_ids(self):
+        return self.ids_map[:, :, 2]
+
 
 class ViewParam(openmc.lib.plot._PlotBase):
     """Viewer settings that are needed for _PlotBase and are independent

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -228,12 +228,21 @@ class PlotModel():
         """
 
         cv = self.currentView = copy.deepcopy(self.activeView)
-        ids = openmc.lib.id_map(cv.view_ind)
-        props = openmc.lib.property_map(cv.view_ind)
+        pv = self.previousViews[-1]  # pv will always be at least 1 to store current views, so only do this if len > 1
+        print(cv.view_ind == pv.view_ind)
 
-        self.cell_ids = ids[:, :, 0]
-        self.instances = ids[:, :, 1]
-        self.mat_ids = ids[:, :, 2]
+        if (len(self.previousViews) == 1 and cv.view_ind == pv.view_ind) or \
+            (cv.view_ind != pv.view_ind):
+            print('here')
+            # we are at the first view and need to populate OR view has changed and need to populate
+            ids = openmc.lib.id_map(cv.view_ind)
+            props = openmc.lib.property_map(cv.view_ind)
+            self.cell_ids = ids[:, :, 0]
+            self.instances = ids[:, :, 1]
+            self.mat_ids = ids[:, :, 2]
+        else:
+            # take ids from last view??
+            pass
 
         # set model ids based on domain
         if cv.colorby == 'cell':
@@ -805,7 +814,7 @@ class PlotViewIndependent(openmc.lib.plot._PlotBase):
         self.color_scale_log = {prop: False for prop in _MODEL_PROPERTIES}
 
         # Tally Viz Settings
-        self.tallyDataColormap = 'spectral'
+        self.tallyDataColormap = 'Spectral'
         self.tallyDataVisible = True
         self.tallyDataAlpha = 1.0
         self.tallyDataIndicator = False
@@ -818,6 +827,16 @@ class PlotViewIndependent(openmc.lib.plot._PlotBase):
         self.tallyValue = "Mean"
         self.tallyContours = False
         self.tallyContourLevels = ""
+
+    def __eq__(self, other):
+        if (isinstance(other, PlotViewIndependent)):
+            for name in self.__dict__:
+                if self.__dict__[name] != other.__dict__[name]:
+                    print(name)
+                    return False
+            return True
+        else:
+            return False
 
     def getDataLimits(self):
         return self.data_minmax

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -953,7 +953,7 @@ class PlotView:
         self.selectedTally = None
 
     def __getattr__(self, name):
-        if name in ['view_ind', 'cells', 'materials', 'selectedTally']:
+        if name in ['view_ind', 'view_params', 'cells', 'materials', 'selectedTally']:
             if name not in self.__dict__:
                 raise AttributeError('{} not in PlotView dict'.format(name))
             return self.__dict__[name]
@@ -964,7 +964,7 @@ class PlotView:
             return getattr(self.view_ind, name)
 
     def __setattr__(self, name, value):
-        if name in ['view_ind', 'cells', 'materials', 'selectedTally']:
+        if name in ['view_ind', 'view_params', 'cells', 'materials', 'selectedTally']:
             super().__setattr__(name, value)
         elif name in ['level', 'origin', 'width', 'height',
                       'h_res', 'v_res', 'basis', 'color_overlaps']:

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -747,17 +747,6 @@ class ViewParam(openmc.lib.plot._PlotBase):
 class PlotViewIndependent():
     """View settings for OpenMC plot, independent of the model.
 
-    Parameters
-    ----------
-    origin : 3-tuple of floats
-        Origin (center) of plot view
-    width: float
-        Width of plot view in model units
-    height : float
-        Height of plot view in model units
-    restore_view : PlotView or PlotViewIndependent or None
-        view object with specified parameters to restore
-
     Attributes
     ----------
     aspectLock : bool
@@ -913,8 +902,23 @@ class PlotViewIndependent():
 class PlotView():
     """Setup the view of the model.
 
+    Parameters
+    ----------
+    origin : 3-tuple of floats
+        Origin (center) of plot view
+    width: float
+        Width of plot view in model units
+    height : float
+        Height of plot view in model units
+    restore_view : PlotView or PlotViewIndependent or None
+        view object with specified parameters to restore
+
     Attributes
     ----------
+    view_ind : PlotViewIndependent instance
+        viewing parameters that are independent of the model
+    view_params : ViewParam instance
+        view parameters necesary for _PlotBase
     cells : Dict of DomainView instances
         Dictionary of cell view settings by ID
     materials : Dict of DomainView instances


### PR DESCRIPTION
I am making this a draft because I think it needs work, but it could use another set of eyes. I think this is a bit clunky the way I have it still.

The point of this change is to separate the viewer settings from the model settings such that when something is reopened, the view can still be reset even if the model has changed. To do that, I separated the `PlotView` class into two classes: `PlotViewIndependent` and `PlotView`. The latter inherits from the former which contains all the model-independent information for the view settings. When `PlotViewIndependent` is initialized, there is the option to use a past view (eg `currentView` from the `plot_settings.pkl` file and it will set all the parameters based on that view. And then `PlotView` will still use the cells and mats from the current load of the model. 

This allows us to remove the checking of the model hashes when we want to load the `plot_settings.pkl` file because instead of loading all the previous information, we just initialize the current model right off the bat with the last view from that `pkl` file and do not worry about the cells, mats, etc. that could have changed. Those will still get loaded in from the current model.

Question: How important is it to reload the `previousViews` and `subsequentViews` from the `plot_settings.pkl` file? Right now with these changes I don't reload those lists only because the mat/cells could be changed from those views. I do have a workaround for that in mind, but I think it would be time consuming to implement for large models (I'll add what am thinking to an inline comment where it should go). If these things are not important, then we could also greatly reduce the size of the `pkl` file that is written out by only saving the `currentView` attributes that are necessary for reloading (and the statepoint file info).

FWIW- I have tested this and it does reliably work to reload changed models but keep the view settings. But it could probably be more elegant.

fixes #96 