### PR TITLE
Material info on right click

### DIFF
--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1232,20 +1232,20 @@ class MainWindow(QMainWindow):
         """display material properties in message box"""
         mat = openmc.lib.materials[id]
         if mat.name:
-            msg_str = "Material {} ({}) Properties\n\n".format(id, mat.name)
+            msg_str = f"Material {id} ({mat.name}) Properties\n\n"
         else:
-            msg_str = "Material {} Properties\n\n".format(id)
+            msg_str = f"Material {id} Properties\n\n"
 
         # get density and temperature
         dens_g = mat.get_density(units='g/cm3')
         dens_a = mat.get_density(units='atom/b-cm')
-        msg_str += "Density: {:.3f} g/cm3 ({:.3e} atom/b-cm)\n".format(dens_g, dens_a)
-        msg_str += "Temperature: {} K\n\n".format(mat.temperature)
+        msg_str += f"Density: {dens_g:.3f} g/cm3 ({dens_a:.3e} atom/b-cm)\n"
+        msg_str += f"Temperature: {mat.temperature} K\n\n"
 
         # get nuclides and their densities
         msg_str += "Nuclide densities [atom/b-cm]:\n"
         for nuc, dens in zip(mat.nuclides, mat.densities):
-            msg_str += '{}: {:5.3e}\n'.format(nuc, dens)
+            msg_str += f'{nuc}: {dens:5.3e}\n'
 
         msg_box = QMessageBox()
         msg_box.setText(msg_str)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -10,7 +10,7 @@ from PySide2.QtGui import QKeyEvent
 from PySide2.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
                                QScrollArea, QMessageBox, QAction, QFileDialog,
                                QColorDialog, QInputDialog, QWidget,
-                               QGestureEvent)
+                               QGestureEvent, QDialog)
 
 import openmc
 import openmc.lib
@@ -528,6 +528,11 @@ class MainWindow(QMainWindow):
             else:
                 message = 'Error loading plot settings. Incompatible model.'
             self.statusBar().showMessage(message, 5000)
+
+    def viewMaterialProps(self, id):
+        msg_box = QMessageBox()
+        msg_box.setText("Testing mat prop box for mat {}".format(id))
+        msg_box.exec_()
 
     def openStatePoint(self):
         # check for an alread-open statepoint

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1247,6 +1247,7 @@ class MainWindow(QMainWindow):
         for nuc, dens in zip(mat.nuclides, mat.densities):
             msg_str += f'{nuc}: {dens:5.3e}\n'
 
-        msg_box = QMessageBox()
+        msg_box = QMessageBox(self)
         msg_box.setText(msg_str)
-        msg_box.exec_()
+        msg_box.setModal(False)
+        msg_box.show()

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -529,11 +529,6 @@ class MainWindow(QMainWindow):
                 message = 'Error loading plot settings. Incompatible model.'
             self.statusBar().showMessage(message, 5000)
 
-    def viewMaterialProps(self, id):
-        msg_box = QMessageBox()
-        msg_box.setText("Testing mat prop box for mat {}".format(id))
-        msg_box.exec_()
-
     def openStatePoint(self):
         # check for an alread-open statepoint
         if self.model.statepoint:
@@ -1233,3 +1228,25 @@ class MainWindow(QMainWindow):
         # show export tool dialog
         self.showExportDialog()
 
+    def viewMaterialProps(self, id):
+        """display material properties in message box"""
+        mat = openmc.lib.materials[id]
+        if mat.name:
+            msg_str = "Material {} ({}) Properties\n\n".format(id, mat.name)
+        else:
+            msg_str = "Material {} Properties\n\n".format(id)
+
+        # get density and temperature
+        dens_g = mat.get_density(units='g/cm3')
+        dens_a = mat.get_density(units='atom/b-cm')
+        msg_str += "Density: {:.3f} g/cm3 ({:.3e} atom/b-cm)\n".format(dens_g, dens_a)
+        msg_str += "Temperature: {} K\n\n".format(mat.temperature)
+
+        # get nuclides and their densities
+        msg_str += "Nuclide densities [atom/b-cm]:\n"
+        for nuc, dens in zip(mat.nuclides, mat.densities):
+            msg_str += '{}: {:5.3e}\n'.format(nuc, dens)
+
+        msg_box = QMessageBox()
+        msg_box.setText(msg_str)
+        msg_box.exec_()

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -10,7 +10,7 @@ from PySide2.QtGui import QKeyEvent
 from PySide2.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
                                QScrollArea, QMessageBox, QAction, QFileDialog,
                                QColorDialog, QInputDialog, QWidget,
-                               QGestureEvent, QDialog)
+                               QGestureEvent)
 
 import openmc
 import openmc.lib

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -1,5 +1,4 @@
 from functools import partial
-from xml import dom
 
 from PySide2 import QtCore, QtGui
 from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -1,4 +1,5 @@
 from functools import partial
+from xml import dom
 
 from PySide2 import QtCore, QtGui
 from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
@@ -354,9 +355,14 @@ class PlotImage(FigureCanvas):
 
             # Domain ID
             if domain[id].name:
-                domainID = self.menu.addAction("{} {}: \"{}\"".format(domain_kind, id, domain[id].name))
+                domainID = self.menu.addAction("{} {} Info: \"{}\"".format(domain_kind, id, domain[id].name))
             else:
-                domainID = self.menu.addAction("{} {}".format(domain_kind, id))
+                domainID = self.menu.addAction("{} {} Info".format(domain_kind, id))
+
+            # add connector to a new window of info here for material props
+            if domain_kind == 'Material':
+                mat_prop_connector = partial(self.main_window.viewMaterialProps, id)
+                domainID.triggered.connect(mat_prop_connector)
 
             self.menu.addSeparator()
 


### PR DESCRIPTION
closes #80 

If you right click on a material, clicking the material id from the menu will now open a message box with information about that material:
- material density
- material temperature
- breakdown of nuclides and their densities
That was all the easily available information in `openmc.lib.materials`, but let me know if there is other information that should be displayed. 

Also, I kind of think it'd be useful if the message box could stay open while using other parts of the gui, or if you could open multiple materials' information at the same time (ie multiple message boxes). But I couldn't figure out the proper way to do that with Qt. Right now, when the message box opens, you have to close it/press ok before doing anything more with the gui.