### PR TITLE
Use trusted publishing for PyPI releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -21,6 +23,3 @@ jobs:
         run: python -m build
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR changes our PyPI release action to use [trusted publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/), which is more secure than the current method.