### PR TITLE
Update github action versions used in python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies


### PR DESCRIPTION
I've noticed a few deprecation warnings elsewhere and I think v2 of the checkout action now fails due to use of an older version of node js

I also updated the python action to v4 while I was having a look at the file