### PR TITLE
Include puns colormaps

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -16,6 +16,7 @@ from .custom_widgets import HorizontalLine, Expander
 from .scientific_spin_box import ScientificDoubleSpinBox
 from .plotmodel import (_SCORE_UNITS, _TALLY_VALUES,
                         _REACTION_UNITS, _SPATIAL_FILTERS)
+import matplotlib.pyplot as plt
 
 
 class PlotterDock(QDockWidget):
@@ -785,7 +786,7 @@ class ColorForm(QWidget):
         self.colormapBox = QComboBox()
         if colormaps is None:
             colormaps = sorted(
-                m for m in mcolormaps._gen_cmap_registry() if not m.endswith("_r"))
+                m for m in plt.colormaps() if not m.endswith("_r"))
         for colormap in colormaps:
             self.colormapBox.addItem(colormap)
         cmap_connector = partial(main_window.editTallyDataColormap)

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -8,7 +8,7 @@ from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
                                QComboBox, QSpinBox, QDoubleSpinBox, QSizePolicy,
                                QCheckBox, QDockWidget, QScrollArea, QListWidget,
                                QListWidgetItem, QTreeWidget, QTreeWidgetItem)
-from matplotlib import cm as mcolormaps
+import matplotlib.pyplot as plt
 import numpy as np
 import openmc
 
@@ -16,7 +16,6 @@ from .custom_widgets import HorizontalLine, Expander
 from .scientific_spin_box import ScientificDoubleSpinBox
 from .plotmodel import (_SCORE_UNITS, _TALLY_VALUES,
                         _REACTION_UNITS, _SPATIAL_FILTERS)
-import matplotlib.pyplot as plt
 
 
 class PlotterDock(QDockWidget):
@@ -635,8 +634,8 @@ class TallyDock(PlotterDock):
                 empty_item = QListWidgetItem()
                 score_box.setFlags(empty_item.flags() |
                                    QtCore.Qt.ItemIsUserCheckable)
-                score_box.setFlags(empty_item.flags() & ~
-                                   QtCore.Qt.ItemIsSelectable)
+                score_box.setFlags(empty_item.flags() &
+                                   ~QtCore.Qt.ItemIsSelectable)
         elif 'total' in applied_scores:
             self.model.appliedScores = ('total',)
             # if total is selected, disable all other scores
@@ -659,8 +658,8 @@ class TallyDock(PlotterDock):
                 else:
                     score_box.setFlags(score_box.flags() |
                                        QtCore.Qt.ItemIsUserCheckable)
-                    score_box.setFlags(score_box.flags() & ~
-                                       QtCore.Qt.ItemIsSelectable)
+                    score_box.setFlags(score_box.flags() &
+                                       ~QtCore.Qt.ItemIsSelectable)
 
     def updateNuclides(self):
         applied_nuclides = []

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -22,6 +22,7 @@ class PlotterDock(QDockWidget):
     """
     Dock widget with common settings for the plotting application
     """
+
     def __init__(self, model, font_metric, parent=None):
         super().__init__(parent)
 
@@ -36,6 +37,7 @@ class DomainDock(PlotterDock):
     """
     Domain options dock
     """
+
     def __init__(self, model, font_metric, parent=None):
         super().__init__(model, font_metric, parent)
 
@@ -159,7 +161,8 @@ class DomainDock(PlotterDock):
         self.domainAlphaBox.setSingleStep(0.05)
         self.domainAlphaBox.setDecimals(2)
         self.domainAlphaBox.setRange(0.0, 1.0)
-        self.domainAlphaBox.valueChanged.connect(self.main_window.editPlotAlpha)
+        self.domainAlphaBox.valueChanged.connect(
+            self.main_window.editPlotAlpha)
 
         # Visibility
         self.visibilityBox = QCheckBox(self)
@@ -179,8 +182,10 @@ class DomainDock(PlotterDock):
 
         # Advanced Color Options
         self.colorOptionsButton = QPushButton('Color Options...')
-        self.colorOptionsButton.setMinimumHeight(self.font_metric.height() * 1.6)
-        self.colorOptionsButton.clicked.connect(self.main_window.showColorDialog)
+        self.colorOptionsButton.setMinimumHeight(
+            self.font_metric.height() * 1.6)
+        self.colorOptionsButton.clicked.connect(
+            self.main_window.showColorDialog)
 
         # Options Form Layout
         self.opLayout = QFormLayout()
@@ -393,16 +398,19 @@ class TallyDock(PlotterDock):
             # make checkable
             if not spatial_filters:
                 filter_item.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                filter_item.setToolTip(0, "Only tallies with spatial filters are viewable.")
+                filter_item.setToolTip(
+                    0, "Only tallies with spatial filters are viewable.")
             else:
-                filter_item.setFlags(filter_item.flags() | QtCore.Qt.ItemIsTristate | QtCore.Qt.ItemIsUserCheckable)
+                filter_item.setFlags(
+                    filter_item.flags() | QtCore.Qt.ItemIsTristate | QtCore.Qt.ItemIsUserCheckable)
             filter_item.setCheckState(0, QtCore.Qt.Unchecked)
 
             # all mesh bins are selected by default and not shown in the dock
             if isinstance(tally_filter, openmc.MeshFilter):
                 filter_item.setCheckState(0, QtCore.Qt.Checked)
                 filter_item.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                filter_item.setToolTip(0, "All Mesh bins are selected automatically")
+                filter_item.setToolTip(
+                    0, "All Mesh bins are selected automatically")
                 continue
 
             def _bin_sort_val(bin):
@@ -423,7 +431,8 @@ class TallyDock(PlotterDock):
                 item = QTreeWidgetItem(filter_item, [str(bin),])
                 if not spatial_filters:
                     item.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                    item.setToolTip(0, "Only tallies with spatial filters are viewable.")
+                    item.setToolTip(
+                        0, "Only tallies with spatial filters are viewable.")
                 else:
                     item.setFlags(item.flags() | QtCore.Qt.ItemIsUserCheckable)
                 item.setCheckState(0, QtCore.Qt.Unchecked)
@@ -487,7 +496,8 @@ class TallyDock(PlotterDock):
 
             if not spatial_filters:
                 self.valueBox.setEnabled(False)
-                self.valueBox.setToolTip("Only tallies with spatial filters are viewable.")
+                self.valueBox.setToolTip(
+                    "Only tallies with spatial filters are viewable.")
 
             # scores
             self.score_map = {}
@@ -520,7 +530,8 @@ class TallyDock(PlotterDock):
 
             self.scoresGroupBoxLayout = QVBoxLayout()
             self.scoresGroupBoxLayout.addWidget(self.scoresListWidget)
-            self.scoresGroupBox = Expander("Scores:", layout=self.scoresGroupBoxLayout)
+            self.scoresGroupBox = Expander(
+                "Scores:", layout=self.scoresGroupBoxLayout)
             self.tallySelectorLayout.addRow(self.scoresGroupBox)
 
             # nuclides
@@ -554,7 +565,8 @@ class TallyDock(PlotterDock):
 
             self.nuclidesGroupBoxLayout = QVBoxLayout()
             self.nuclidesGroupBoxLayout.addWidget(self.nuclidesListWidget)
-            self.nuclidesGroupBox = Expander("Nuclides:", layout=self.nuclidesGroupBoxLayout)
+            self.nuclidesGroupBox = Expander(
+                "Nuclides:", layout=self.nuclidesGroupBoxLayout)
             self.tallySelectorLayout.addRow(self.nuclidesGroupBox)
 
     def updateMinMax(self):
@@ -620,27 +632,34 @@ class TallyDock(PlotterDock):
             for score, score_box in self.score_map.items():
                 sunits = _SCORE_UNITS.get(score, _REACTION_UNITS)
                 empty_item = QListWidgetItem()
-                score_box.setFlags(empty_item.flags() | QtCore.Qt.ItemIsUserCheckable)
-                score_box.setFlags(empty_item.flags() & ~QtCore.Qt.ItemIsSelectable)
+                score_box.setFlags(empty_item.flags() |
+                                   QtCore.Qt.ItemIsUserCheckable)
+                score_box.setFlags(empty_item.flags() & ~
+                                   QtCore.Qt.ItemIsSelectable)
         elif 'total' in applied_scores:
             self.model.appliedScores = ('total',)
             # if total is selected, disable all other scores
             for score, score_box in self.score_map.items():
                 if score != 'total':
                     score_box.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                    score_box.setToolTip("De-select 'total' to enable other scores")
+                    score_box.setToolTip(
+                        "De-select 'total' to enable other scores")
         else:
             # get units of applied scores
-            selected_units = _SCORE_UNITS.get(applied_scores[0], _REACTION_UNITS)
+            selected_units = _SCORE_UNITS.get(
+                applied_scores[0], _REACTION_UNITS)
             # disable scores with incompatible units
             for score, score_box in self.score_map.items():
                 sunits = _SCORE_UNITS.get(score, _REACTION_UNITS)
                 if sunits != selected_units:
                     score_box.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                    score_box.setToolTip("Score is incompatible with currently selected scores")
+                    score_box.setToolTip(
+                        "Score is incompatible with currently selected scores")
                 else:
-                    score_box.setFlags(score_box.flags() | QtCore.Qt.ItemIsUserCheckable)
-                    score_box.setFlags(score_box.flags() & ~QtCore.Qt.ItemIsSelectable)
+                    score_box.setFlags(score_box.flags() |
+                                       QtCore.Qt.ItemIsUserCheckable)
+                    score_box.setFlags(score_box.flags() & ~
+                                       QtCore.Qt.ItemIsSelectable)
 
     def updateNuclides(self):
         applied_nuclides = []
@@ -654,13 +673,16 @@ class TallyDock(PlotterDock):
             for nuclide, nuclide_box in self.nuclide_map.items():
                 if nuclide != 'total':
                     nuclide_box.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                    nuclide_box.setToolTip("De-select 'total' to enable other nuclides")
+                    nuclide_box.setToolTip(
+                        "De-select 'total' to enable other nuclides")
         elif not applied_nuclides:
             # if no nuclides are selected, enable all nuclides again
             for nuclide, nuclide_box in self.nuclide_map.items():
                 empty_item = QListWidgetItem()
-                nuclide_box.setFlags(empty_item.flags() | QtCore.Qt.ItemIsUserCheckable)
-                nuclide_box.setFlags(empty_item.flags() & ~QtCore.Qt.ItemIsSelectable)
+                nuclide_box.setFlags(empty_item.flags() |
+                                     QtCore.Qt.ItemIsUserCheckable)
+                nuclide_box.setFlags(empty_item.flags() &
+                                     ~QtCore.Qt.ItemIsSelectable)
 
     def updateModel(self):
         self.updateFilters()
@@ -678,9 +700,11 @@ class TallyDock(PlotterDock):
             self.tallySelector.addItem("None")
             for idx, tally in enumerate(self.model.statepoint.tallies.values()):
                 if tally.name == "":
-                    self.tallySelector.addItem(f'Tally {tally.id}', userData=tally.id)
+                    self.tallySelector.addItem(
+                        f'Tally {tally.id}', userData=tally.id)
                 else:
-                    self.tallySelector.addItem(f'Tally {tally.id} "{tally.name}"', userData=tally.id)
+                    self.tallySelector.addItem(
+                        f'Tally {tally.id} "{tally.name}"', userData=tally.id)
                 self.tally_map[idx] = tally
             self.updateSelectedTally()
             self.updateMinMax()
@@ -734,6 +758,7 @@ class ColorForm(QWidget):
         comma-separated set of values is entered, those values will be used as
         levels in the contour plot.
     """
+
     def __init__(self, model, main_window, field, colormaps=None):
         super().__init__()
 
@@ -759,7 +784,8 @@ class ColorForm(QWidget):
         # Color map selector
         self.colormapBox = QComboBox()
         if colormaps is None:
-            colormaps = sorted(m for m in mcolormaps.datad if not m.endswith("_r"))
+            colormaps = sorted(
+                m for m in mcolormaps._gen_cmap_registry() if not m.endswith("_r"))
         for colormap in colormaps:
             self.colormapBox.addItem(colormap)
         cmap_connector = partial(main_window.editTallyDataColormap)
@@ -767,8 +793,10 @@ class ColorForm(QWidget):
 
         # Data indicator line check box
         self.dataIndicatorCheckBox = QCheckBox()
-        data_indicator_connector = partial(main_window.toggleTallyDataIndicator)
-        self.dataIndicatorCheckBox.stateChanged.connect(data_indicator_connector)
+        data_indicator_connector = partial(
+            main_window.toggleTallyDataIndicator)
+        self.dataIndicatorCheckBox.stateChanged.connect(
+            data_indicator_connector)
 
         # User specified min/max check box
         self.userMinMaxBox = QCheckBox()

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -8,8 +8,9 @@ from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
                                QTabWidget, QTableView, QHeaderView)
 from matplotlib.figure import Figure
 from matplotlib import lines as mlines
-from matplotlib import cm as mcolormaps
 from matplotlib.colors import SymLogNorm
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+import matplotlib.pyplot as plt
 import numpy as np
 
 from .plot_colors import rgb_normalize, invert_rgb
@@ -18,8 +19,6 @@ from .plotmodel import _NOT_FOUND, _VOID_REGION, _OVERLAP, _MODEL_PROPERTIES
 from .scientific_spin_box import ScientificDoubleSpinBox
 from .custom_widgets import HorizontalLine
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
-import matplotlib.pyplot as plt
 
 
 class PlotImage(FigureCanvas):

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -19,6 +19,7 @@ from .scientific_spin_box import ScientificDoubleSpinBox
 from .custom_widgets import HorizontalLine
 
 from matplotlib.backends.backend_qt5agg import FigureCanvas
+import matplotlib.pyplot as plt
 
 
 class PlotImage(FigureCanvas):
@@ -927,7 +928,7 @@ class ColorDialog(QDialog):
         propertyTab.maxBox.valueChanged.connect(connector3)
 
         propertyTab.colormapBox = QComboBox(self)
-        cmaps = sorted(m for m in mcolormaps._gen_cmap_registry()
+        cmaps = sorted(m for m in plt.colormaps()
                        if not m.endswith("_r"))
         for cmap in cmaps:
             propertyTab.colormapBox.addItem(cmap)

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -267,7 +267,7 @@ class PlotImage(FigureCanvas):
                                   domain[id].name,
                                   density,
                                   temperature
-                             ))
+                              ))
             elif id != _NOT_FOUND:
                 domainInfo = ("{} {}{}\t Density: {} g/cc\t"
                               "Temperature: {} K".format(domain_kind,
@@ -282,7 +282,8 @@ class PlotImage(FigureCanvas):
                 tid, value = self.getTallyInfo(event)
                 if value is not None and value != np.nan:
                     self.updateTallyDataIndicatorValue(value)
-                    tallyInfo = "Tally {} {}: {:.5E}".format(tid, cv.tallyValue, value)
+                    tallyInfo = "Tally {} {}: {:.5E}".format(
+                        tid, cv.tallyValue, value)
                 else:
                     self.updateTallyDataIndicatorValue(0.0)
         else:
@@ -348,8 +349,10 @@ class PlotImage(FigureCanvas):
 
         self.menu.clear()
 
-        self.main_window.undoAction.setText('&Undo ({})'.format(len(self.model.previousViews)))
-        self.main_window.redoAction.setText('&Redo ({})'.format(len(self.model.subsequentViews)))
+        self.main_window.undoAction.setText(
+            '&Undo ({})'.format(len(self.model.previousViews)))
+        self.main_window.redoAction.setText(
+            '&Redo ({})'.format(len(self.model.subsequentViews)))
 
         id, instance, properties, domain, domain_kind = self.getIDinfo(event)
 
@@ -366,18 +369,22 @@ class PlotImage(FigureCanvas):
 
             # Domain ID
             if domain[id].name:
-                domainID = self.menu.addAction("{} {} Info: \"{}\"".format(domain_kind, id, domain[id].name))
+                domainID = self.menu.addAction(
+                    "{} {} Info: \"{}\"".format(domain_kind, id, domain[id].name))
             else:
-                domainID = self.menu.addAction("{} {} Info".format(domain_kind, id))
+                domainID = self.menu.addAction(
+                    "{} {} Info".format(domain_kind, id))
 
             # add connector to a new window of info here for material props
             if domain_kind == 'Material':
-                mat_prop_connector = partial(self.main_window.viewMaterialProps, id)
+                mat_prop_connector = partial(
+                    self.main_window.viewMaterialProps, id)
                 domainID.triggered.connect(mat_prop_connector)
 
             self.menu.addSeparator()
 
-            colorAction = self.menu.addAction('Edit {} Color...'.format(domain_kind))
+            colorAction = self.menu.addAction(
+                'Edit {} Color...'.format(domain_kind))
             colorAction.setDisabled(cv.highlighting)
             colorAction.setToolTip('Edit {} color'.format(domain_kind))
             colorAction.setStatusTip('Edit {} color'.format(domain_kind))
@@ -397,12 +404,15 @@ class PlotImage(FigureCanvas):
                                      id=id)
             maskAction.toggled.connect(mask_connector)
 
-            highlightAction = self.menu.addAction('Highlight {}'.format(domain_kind))
+            highlightAction = self.menu.addAction(
+                'Highlight {}'.format(domain_kind))
             highlightAction.setCheckable(True)
             highlightAction.setChecked(domain[id].highlight)
             highlightAction.setDisabled(not cv.highlighting)
-            highlightAction.setToolTip('Toggle {} highlight'.format(domain_kind))
-            highlightAction.setStatusTip('Toggle {} highlight'.format(domain_kind))
+            highlightAction.setToolTip(
+                'Toggle {} highlight'.format(domain_kind))
+            highlightAction.setStatusTip(
+                'Toggle {} highlight'.format(domain_kind))
             highlight_connector = partial(self.main_window.toggleDomainHighlight,
                                           kind=domain_kind,
                                           id=id)
@@ -415,14 +425,16 @@ class PlotImage(FigureCanvas):
             if cv.colorby not in _MODEL_PROPERTIES:
                 self.menu.addSeparator()
                 if int(id) == _NOT_FOUND:
-                    bgColorAction = self.menu.addAction('Edit Background Color...')
+                    bgColorAction = self.menu.addAction(
+                        'Edit Background Color...')
                     bgColorAction.setToolTip('Edit background color')
                     bgColorAction.setStatusTip('Edit plot background color')
                     connector = partial(self.main_window.editBackgroundColor,
                                         apply=True)
                     bgColorAction.triggered.connect(connector)
                 elif int(id) == _OVERLAP:
-                    olapColorAction = self.menu.addAction('Edit Overlap Color...')
+                    olapColorAction = self.menu.addAction(
+                        'Edit Overlap Color...')
                     olapColorAction.setToolTip('Edit overlap color')
                     olapColorAction.setStatusTip('Edit plot overlap color')
                     connector = partial(self.main_window.editOverlapColor,
@@ -503,7 +515,8 @@ class PlotImage(FigureCanvas):
                 idx = 1
                 cmap_label = "Density (g/cc)"
 
-            norm = SymLogNorm(1E-10) if cv.color_scale_log[cv.colorby] else None
+            norm = SymLogNorm(
+                1E-10) if cv.color_scale_log[cv.colorby] else None
 
             data = self.model.properties[:, :, idx]
             self.image = self.figure.subplots().imshow(data,
@@ -526,7 +539,7 @@ class PlotImage(FigureCanvas):
                                                 color='blue',
                                                 clip_on=True)
             self.colorbar.ax.add_line(self.data_indicator)
-            self.colorbar.ax.margins(0.0 ,0.0)
+            self.colorbar.ax.margins(0.0, 0.0)
             self.updateDataIndicatorVisibility()
             self.updateColorMinMax(cv.colorby)
 
@@ -667,7 +680,7 @@ class PlotImage(FigureCanvas):
         cv = self.model.currentView
 
         if not cv.tallyDataVisible or not cv.tallyDataIndicator:
-             return
+            return
 
         if self.tally_data_indicator is not None:
             data = self.tally_data_indicator.get_data()
@@ -719,6 +732,7 @@ class PlotImage(FigureCanvas):
             self.colorbar.draw_all()
             self.draw()
 
+
 class ColorDialog(QDialog):
 
     def __init__(self, model, font_metric, parent=None):
@@ -745,7 +759,8 @@ class ColorDialog(QDialog):
 
         self.tab_bar = QTabWidget()
         self.tab_bar.setMaximumHeight(800)
-        self.tab_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.tab_bar.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.tab_bar.addTab(self.generalTab, 'General')
         self.tab_bar.addTab(self.tabs['cell'], 'Cells')
         self.tab_bar.addTab(self.tabs['material'], 'Materials')
@@ -805,13 +820,15 @@ class ColorDialog(QDialog):
         self.colorbyBox.addItem("cell")
         self.colorbyBox.addItem("temperature")
         self.colorbyBox.addItem("density")
-        self.colorbyBox.currentTextChanged[str].connect(main_window.editColorBy)
+        self.colorbyBox.currentTextChanged[str].connect(
+            main_window.editColorBy)
 
         self.universeLevelBox = QComboBox(self)
         self.universeLevelBox.addItem('all')
         for i in range(self.model.max_universe_levels):
             self.universeLevelBox.addItem(str(i))
-        self.universeLevelBox.currentTextChanged[str].connect(main_window.editUniverseLevel)
+        self.universeLevelBox.currentTextChanged[str].connect(
+            main_window.editUniverseLevel)
 
         # Overlap plotting
         self.overlapCheck = QCheckBox('', self)
@@ -910,7 +927,8 @@ class ColorDialog(QDialog):
         propertyTab.maxBox.valueChanged.connect(connector3)
 
         propertyTab.colormapBox = QComboBox(self)
-        cmaps = sorted(m for m in mcolormaps.datad if not m.endswith("_r"))
+        cmaps = sorted(m for m in mcolormaps._gen_cmap_registry()
+                       if not m.endswith("_r"))
         for cmap in cmaps:
             propertyTab.colormapBox.addItem(cmap)
 
@@ -958,8 +976,8 @@ class ColorDialog(QDialog):
         cmaps = self.model.activeView.colormaps
         for key, val in cmaps.items():
             idx = self.tabs[key].colormapBox.findText(
-                    val,
-                    QtCore.Qt.MatchFixedString)
+                val,
+                QtCore.Qt.MatchFixedString)
             if idx >= 0:
                 self.tabs[key].colormapBox.setCurrentIndex(idx)
 


### PR DESCRIPTION
Hi! I noticed that the plotter does not allow for perceptually uniform sequential colormaps (e.g. viridis, cividis, plasma etc.). This PR includes them.
It was sufficient to substitute:

`mcolormaps.datad`

with:

`mcolormaps._gen_cmap_registry()`

in [docks.py](https://github.com/openmc-dev/plotter/blob/develop/openmc_plotter/docks.py) and [plotgui.py](https://github.com/openmc-dev/plotter/blob/develop/openmc_plotter/plotgui.py) files.

![Picture1](https://github.com/openmc-dev/plotter/assets/92783079/57b6705c-9822-4ece-b42e-bd39d5ce92a9)
