### PR TITLE
Update use of obsolete features in Qt5

### DIFF
--- a/openmc_plotter/overlays.py
+++ b/openmc_plotter/overlays.py
@@ -101,18 +101,18 @@ class ShortcutsOverlay(QWidget):
         for menu in self.shortcuts:
             # set menu header
             header_item = self.tableWidget.item(row_idx, col_idx)
-            header_item.setTextColor(QtGui.QColor(150, 150, 150, 255))
+            header_item.setForeground(QtGui.QColor(150, 150, 150, 255))
             header_item.setText(menu)
             header_item.setFlags(QtCore.Qt.NoItemFlags)
             row_idx += 1
 
             for shortcut in self.shortcuts[menu]:
                 desc_item = self.tableWidget.item(row_idx, col_idx)
-                desc_item.setTextColor(self.textPenColor)
+                desc_item.setForeground(self.textPenColor)
                 desc_item.setText(shortcut[0])
 
                 key_item = self.tableWidget.item(row_idx, col_idx + 1)
-                key_item.setTextColor(self.textPenColor)
+                key_item.setForeground(self.textPenColor)
                 key_item.setText(shortcut[1])
                 row_idx += 1
             # update for next menu

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -482,7 +482,7 @@ class PlotImage(FigureCanvas):
 
         cv = self.model.currentView
         # set figure bg color to match window
-        window_bg = self.parent.palette().color(QtGui.QPalette.Background)
+        window_bg = self.parent.palette().color(QtGui.QPalette.Window)
         self.figure.patch.set_facecolor(rgb_normalize(window_bg.getRgb()))
 
         # set data extents for automatic reporting of pointer location

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -1182,7 +1182,7 @@ class DomainTableModel(QAbstractTableModel):
             else:
                 return int(Qt.AlignLeft | Qt.AlignVCenter)
 
-        elif role == Qt.BackgroundColorRole:
+        elif role == Qt.BackgroundRole:
             color = domain.color
             if column == COLOR:
                 if isinstance(color, tuple):


### PR DESCRIPTION
There are a few things we use from Qt5 that are already obsolete (and are removed in Qt6). This PR will minimize the number of changes needed to move from PySide2 to PySide6.