### PR TITLE
Instructions for development version install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This package is most easily installed by running
 pip install openmc-plotter
 ```
 
+The development version can be installed with
+
+```
+pip install git+https://github.com/openmc-dev/openmc.git@develop
+```
+
 ## Usage
 
 From a directory containing an OpenMC model run:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install openmc-plotter
 The development version can be installed with
 
 ```
-pip install git+https://github.com/openmc-dev/openmc.git@develop
+pip install git+https://github.com/openmc-dev/plotter.git@develop
 ```
 
 ## Usage


### PR DESCRIPTION
Just wondering if it is worth adding another install option for people wanting the development version.

The development version occasionally has a few fixes that would help users