### PR TITLE
Fix inconsistent model refresh threading

### DIFF
--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -68,7 +68,7 @@ def run_app(user_args):
 
     font_metric = QtGui.QFontMetrics(app.font())
     screen_size = app.primaryScreen().size()
-    mainWindow = MainWindow(font_metric, screen_size, user_args.model_path)
+    mainWindow = MainWindow(font_metric, screen_size, user_args.model_path, user_args.threads)
     # connect splashscreen to main window, close when main window opens
     mainWindow.loadGui(use_settings_pkl=user_args.ignore_settings)
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -45,13 +45,14 @@ class MainWindow(QMainWindow):
     def __init__(self,
                  font=QtGui.QFontMetrics(QtGui.QFont()),
                  screen_size=QtCore.QSize(),
-                 model_path='.'):
+                 model_path='.', threads=None):
         super().__init__()
 
         self.screen = screen_size
         self.font_metric = font
         self.setWindowTitle('OpenMC Plot Explorer')
         self.model_path = Path(model_path)
+        self.threads = threads
 
     def loadGui(self, use_settings_pkl=True):
 
@@ -478,8 +479,10 @@ class MainWindow(QMainWindow):
         self.cellsModel = DomainTableModel(self.model.activeView.cells)
         self.materialsModel = DomainTableModel(self.model.activeView.materials)
 
+        openmc_args = {'threads': self.threads, 'model_path': self.model_path}
+
         if reload:
-            loader_thread = Thread(target=_openmcReload)
+            loader_thread = Thread(target=_openmcReload, kwargs=openmc_args)
             loader_thread.start()
             while loader_thread.is_alive():
                 self.statusBar().showMessage("Reloading model...")


### PR DESCRIPTION
When calling `openmc-plotter` with the `-s` flag and specifying threads, this number would only be remembered for the first time loading the model. Any subsequent reloads called from the GUI would function as if `openmc-plotter` were run with no thread specification, returning to the default value for that machine.

This pull request adds a quick fix to enable any future loads/reloads of the model to use the number of threads as specified by the initial call of `openmc-plotter`.