### PR TITLE
Pyside6 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev libxkbcommon-x11-0 xvfb
+          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev libxkbcommon-x11-0 xvfb libdbus-1-3
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
       -
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev libxkbcommon-x11-0
+          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev libxkbcommon-x11-0 xvfb
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
       -
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1
+          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev
       -
         uses: actions/checkout@v2
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,16 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     container: openmc/openmc:develop
+    env:
+      DISPLAY: ':99.0'
     steps:
       -
         name: Apt dependencies
         shell: bash
         run: |
           apt update
-          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev
+          apt install -y libglu1-mesa libglib2.0-0 libfontconfig1 libegl-dev libxkbcommon-x11-0
+          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
       -
         uses: actions/checkout@v2
       -

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repository](https://github.com/landonjmitchell/openmc-plotgui)).
 
 ## Dependencies
 
-OpenMC, Matplotlib, NumPy, PySide2
+OpenMC, Matplotlib, NumPy, PySide6
 
 ## Installation
 

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -90,7 +90,7 @@ def run_app(user_args):
     timer.start(500)
     timer.timeout.connect(lambda: None)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 if __name__ == '__main__':
     main()

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -5,8 +5,8 @@ import os
 import signal
 import sys
 
-from PySide2 import QtCore, QtGui
-from PySide2.QtWidgets import QApplication, QSplashScreen
+from PySide6 import QtCore, QtGui
+from PySide6.QtWidgets import QApplication, QSplashScreen
 
 from . import __version__
 from .main_window import MainWindow, _openmcReload

--- a/openmc_plotter/custom_widgets.py
+++ b/openmc_plotter/custom_widgets.py
@@ -1,8 +1,8 @@
 from functools import partial
 import warnings
 
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtWidgets import QFrame
+from PySide6 import QtWidgets, QtCore
+from PySide6.QtWidgets import QFrame
 
 
 class HorizontalLine(QFrame):

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -384,7 +384,8 @@ class TallyDock(PlotterDock):
 
         header = QTreeWidgetItem(["Filters"])
         self.filterTree.setHeaderItem(header)
-        self.filterTree.setItemHidden(header, True)
+        header.setHidden(True)
+        #self.filterTree.setItemHidden(header, True)
         self.filterTree.setColumnCount(1)
 
         self.filter_map = {}
@@ -402,7 +403,7 @@ class TallyDock(PlotterDock):
                     0, "Only tallies with spatial filters are viewable.")
             else:
                 filter_item.setFlags(
-                    filter_item.flags() | QtCore.Qt.ItemIsTristate | QtCore.Qt.ItemIsUserCheckable)
+                    filter_item.flags() | QtCore.Qt.ItemIsUserCheckable)
             filter_item.setCheckState(0, QtCore.Qt.Unchecked)
 
             # all mesh bins are selected by default and not shown in the dock

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -2,8 +2,8 @@ from functools import partial
 from collections.abc import Iterable
 from collections import defaultdict
 
-from PySide2 import QtCore
-from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
+from PySide6 import QtCore
+from PySide6.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
                                QGroupBox, QFormLayout, QLabel, QLineEdit,
                                QComboBox, QSpinBox, QDoubleSpinBox, QSizePolicy,
                                QCheckBox, QDockWidget, QScrollArea, QListWidget,

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -547,7 +547,7 @@ class MainWindow(QMainWindow):
                             "opening a new one.")
             msg_box.setIcon(QMessageBox.Information)
             msg_box.setStandardButtons(QMessageBox.Ok)
-            msg_box.exec_()
+            msg_box.exec()
             return
         filename, ext = QFileDialog.getOpenFileName(self, "Open StatePoint",
                                                     ".", "statepoint*.h5")
@@ -562,7 +562,7 @@ class MainWindow(QMainWindow):
                 msg_box.setText(msg.format(filename))
                 msg_box.setIcon(QMessageBox.Warning)
                 msg_box.setStandardButtons(QMessageBox.Ok)
-                msg_box.exec_()
+                msg_box.exec()
             finally:
                 self.statusBar().showMessage(message.format(filename), 5000)
             self.updateDataMenu()
@@ -583,7 +583,7 @@ class MainWindow(QMainWindow):
             msg_box.setText(f"Error opening properties file: \n\n {e} \n")
             msg_box.setIcon(QMessageBox.Warning)
             msg_box.setStandardButtons(QMessageBox.Ok)
-            msg_box.exec_()
+            msg_box.exec()
         finally:
             self.statusBar().showMessage(message.format(filename), 5000)
 
@@ -869,7 +869,7 @@ class MainWindow(QMainWindow):
         dlg = QColorDialog(self)
 
         dlg.setCurrentColor(QtGui.QColor.fromRgb(*current_color))
-        if dlg.exec_():
+        if dlg.exec():
             new_color = dlg.currentColor().getRgb()[:3]
             self.model.activeView.maskBackground = new_color
             self.colorDialog.updateMaskingColor()
@@ -879,7 +879,7 @@ class MainWindow(QMainWindow):
         dlg = QColorDialog(self)
 
         dlg.setCurrentColor(QtGui.QColor.fromRgb(*current_color))
-        if dlg.exec_():
+        if dlg.exec():
             new_color = dlg.currentColor().getRgb()[:3]
             self.model.activeView.highlightBackground = new_color
             self.colorDialog.updateHighlightColor()
@@ -894,7 +894,7 @@ class MainWindow(QMainWindow):
         current_color = self.model.activeView.overlap_color
         dlg = QColorDialog(self)
         dlg.setCurrentColor(QtGui.QColor.fromRgb(*current_color))
-        if dlg.exec_():
+        if dlg.exec():
             new_color = dlg.currentColor().getRgb()[:3]
             self.model.activeView.overlap_color = new_color
             self.colorDialog.updateOverlapColor()
@@ -907,7 +907,7 @@ class MainWindow(QMainWindow):
         dlg = QColorDialog(self)
 
         dlg.setCurrentColor(QtGui.QColor.fromRgb(*current_color))
-        if dlg.exec_():
+        if dlg.exec():
             new_color = dlg.currentColor().getRgb()[:3]
             self.model.activeView.domainBackground = new_color
             self.colorDialog.updateBackgroundColor()
@@ -1036,7 +1036,7 @@ class MainWindow(QMainWindow):
         elif isinstance(current_color, str):
             current_color = openmc.plots._SVG_COLORS[current_color]
             dlg.setCurrentColor(QtGui.QColor.fromRgb(*current_color))
-        if dlg.exec_():
+        if dlg.exec():
             new_color = dlg.currentColor().getRgb()[:3]
             domain[id].color = new_color
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import pickle
 from threading import Thread
 
-from PySide2 import QtCore, QtGui
-from PySide2.QtGui import QKeyEvent
-from PySide2.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
-                               QScrollArea, QMessageBox, QAction, QFileDialog,
+from PySide6 import QtCore, QtGui
+from PySide6.QtGui import QKeyEvent, QAction
+from PySide6.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
+                               QScrollArea, QMessageBox, QFileDialog,
                                QColorDialog, QInputDialog, QWidget,
                                QGestureEvent)
 

--- a/openmc_plotter/overlays.py
+++ b/openmc_plotter/overlays.py
@@ -1,7 +1,7 @@
 from sys import platform
 
-from PySide2 import QtGui, QtCore
-from PySide2.QtWidgets import (QWidget, QTableWidget, QSizePolicy,
+from PySide6 import QtGui, QtCore
+from PySide6.QtWidgets import (QWidget, QTableWidget, QSizePolicy,
                                QPushButton, QTableWidgetItem, QVBoxLayout)
 
 c_key = "⌘" if platform == 'darwin' else "Ctrl"

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -1,7 +1,7 @@
 from functools import partial
 
-from PySide2 import QtCore, QtGui
-from PySide2.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
+from PySide6 import QtCore, QtGui
+from PySide6.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
                                QFormLayout, QComboBox, QSpinBox,
                                QDoubleSpinBox, QSizePolicy, QMessageBox,
                                QCheckBox, QRubberBand, QMenu, QDialog,

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -465,7 +465,7 @@ class PlotImage(FigureCanvas):
         else:
             self.main_window.dockAction.setText('Show &Dock')
 
-        self.menu.exec_(event.globalPos())
+        self.menu.exec(event.globalPos())
 
     def generatePixmap(self, update=False):
         if self.frozen:

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -180,7 +180,7 @@ class PlotModel:
                     msg_box.setText(msg)
                     msg_box.setIcon(QMessageBox.Warning)
                     msg_box.setStandardButtons(QMessageBox.Ok)
-                    msg_box.exec_()
+                    msg_box.exec()
                     self.currentView = copy.deepcopy(self.defaultView)
 
                 else:
@@ -212,7 +212,7 @@ class PlotModel:
                             msg_box.setText(msg.format(self.model.statepoint.filename))
                             msg_box.setIcon(QMessageBox.Warning)
                             msg_box.setStandardButtons(QMessageBox.Ok)
-                            msg_box.exec_()
+                            msg_box.exec()
                             self.statepoint = None
 
                     self.currentView = PlotView(restore_view=view,
@@ -427,7 +427,7 @@ class PlotModel:
             msg_box.setText(msg)
             msg_box.setIcon(QMessageBox.Information)
             msg_box.setStandardButtons(QMessageBox.Ok)
-            msg_box.exec_()
+            msg_box.exec()
             return (None, None, None, None, None)
 
         units_out = list(units)[0]

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -8,9 +8,9 @@ from pathlib import Path
 import pickle
 import threading
 
-from PySide2.QtWidgets import QItemDelegate, QColorDialog, QLineEdit, QMessageBox
-from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt, QSize, QEvent
-from PySide2.QtGui import QColor
+from PySide6.QtWidgets import QItemDelegate, QColorDialog, QLineEdit, QMessageBox
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt, QSize, QEvent
+from PySide6.QtGui import QColor
 import openmc
 import openmc.lib
 import numpy as np

--- a/openmc_plotter/scientific_spin_box.py
+++ b/openmc_plotter/scientific_spin_box.py
@@ -1,7 +1,7 @@
 import re
 
-from PySide2 import QtGui
-from PySide2.QtWidgets import QDoubleSpinBox
+from PySide6 import QtGui
+from PySide6.QtWidgets import QDoubleSpinBox
 import numpy as np
 
 # Regular expression to find floats. Match groups are the whole string, the

--- a/openmc_plotter/tools.py
+++ b/openmc_plotter/tools.py
@@ -36,7 +36,7 @@ class ExportDataDialog(QtWidgets.QDialog):
         msg_box.setText(msg)
         msg_box.setIcon(QtWidgets.QMessageBox.Information)
         msg_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
-        msg_box.exec_()
+        msg_box.exec()
 
     def populate(self):
         cv = self.model.currentView
@@ -378,4 +378,4 @@ class ExportDataDialog(QtWidgets.QDialog):
         msg.setText("Export complete!")
         msg.setIcon(QtWidgets.QMessageBox.Information)
         msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-        msg.exec_()
+        msg.exec()

--- a/openmc_plotter/tools.py
+++ b/openmc_plotter/tools.py
@@ -2,7 +2,7 @@ import copy
 
 import numpy as np
 import openmc
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from .custom_widgets import HorizontalLine
 from .scientific_spin_box import ScientificDoubleSpinBox

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-qt_api=pyside2
+qt_api=pyside6
 python_files = test*.py
 python_classes = NoThanks
 filterwarnings = ignore::UserWarning

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ kwargs = {
     # Dependencies
     'python_requires': '>=3.6',
     'install_requires': [
-        'openmc>0.12.2', 'numpy', 'matplotlib', 'PySide2'
+        'openmc>0.12.2', 'numpy', 'matplotlib', 'PySide6'
     ],
     'extras_require': {
         'test' : ['pytest', 'pytest-qt'],


### PR DESCRIPTION
I just wanted to get this process started since I too was running into some Python 3.11 issues with the plotter. I've done some testing with this PR and things seem to work fine although my testing has been pretty sparse so far. FWIW I got this working locally by specifying the environment variable `QT_QPA_PLATFORM_PLUGIN_PATH` to point to the Qt installation included with PySide6. I don't yet know the best way to facilitate this for the user since I think matplotlib will also install its own version of Qt? Maybe figuring out how to specify that version in the openmc install so that it's compatible with PySide6 and in the plotter install directing it to the Qt installation included with matplotlib? No idea, but open to suggestions.