### PR TITLE
Generalize mesh tally plotting

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -887,6 +887,10 @@ class ColorForm(QWidget):
         cv = self.model.currentView
         self.maskZeroBox.setChecked(cv.tallyMaskZeroValues)
 
+    def updateVolumeNorm(self):
+        cv = self.model.currentView
+        self.volumeNormBox.setChecked(cv.tallyVolumeNorm)
+
     def updateDataClip(self):
         cv = self.model.currentView
         self.clipDataBox.setChecked(cv.clipTallyData)
@@ -906,6 +910,7 @@ class ColorForm(QWidget):
 
         self.updateMinMax()
         self.updateMaskZeros()
+        self.updateVolumeNorm()
         self.updateDataClip()
         self.updateDataIndicator()
         self.updateTallyContours()

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -670,7 +670,7 @@ class TallyDock(PlotterDock):
         self.model.appliedNuclides = tuple(applied_nuclides)
 
         if 'total' in applied_nuclides:
-            self.model.appliedNuclides = ['total',]
+            self.model.appliedNuclides = ('total',)
             for nuclide, nuclide_box in self.nuclide_map.items():
                 if nuclide != 'total':
                     nuclide_box.setFlags(QtCore.Qt.ItemIsUserCheckable)

--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -826,6 +826,11 @@ class ColorForm(QWidget):
         zero_connector = partial(main_window.toggleTallyMaskZero)
         self.maskZeroBox.stateChanged.connect(zero_connector)
 
+        # Volume normalization check box
+        self.volumeNormBox = QCheckBox()
+        volume_connector = partial(main_window.toggleTallyVolumeNorm)
+        self.volumeNormBox.stateChanged.connect(volume_connector)
+
         # Clip data to min/max check box
         self.clipDataBox = QCheckBox()
         clip_connector = partial(main_window.toggleTallyDataClip)
@@ -849,6 +854,7 @@ class ColorForm(QWidget):
         self.layout.addRow("Log Scale: ", self.scaleBox)
         self.layout.addRow("Clip Data: ", self.clipDataBox)
         self.layout.addRow("Mask Zeros: ", self.maskZeroBox)
+        self.layout.addRow("Volume normalize: ", self.volumeNormBox)
         self.layout.addRow("Contours: ", self.contoursBox)
         self.layout.addRow("Contour Levels:", self.contourLevelsLine)
         self.setLayout(self.layout)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -550,7 +550,7 @@ class MainWindow(QMainWindow):
             msg_box.exec()
             return
         filename, ext = QFileDialog.getOpenFileName(self, "Open StatePoint",
-                                                    ".", "statepoint*.h5")
+                                                    ".", "*.h5")
         if filename:
             try:
                 self.model.openStatePoint(filename)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -951,6 +951,10 @@ class MainWindow(QMainWindow):
         av = self.model.activeView
         av.tallyMaskZeroValues = bool(state)
 
+    def toggleTallyVolumeNorm(self, state):
+        av = self.model.activeView
+        av.tallyVolumeNorm = bool(state)
+
     def editTallyAlpha(self, value, apply=False):
         av = self.model.activeView
         av.tallyDataAlpha = value

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from .plot_colors import rgb_normalize, invert_rgb
-from .plotmodel import DomainDelegate
+from .plotmodel import DomainDelegate, PlotModel
 from .plotmodel import _NOT_FOUND, _VOID_REGION, _OVERLAP, _MODEL_PROPERTIES
 from .scientific_spin_box import ScientificDoubleSpinBox
 from .custom_widgets import HorizontalLine
@@ -23,7 +23,7 @@ from .custom_widgets import HorizontalLine
 
 class PlotImage(FigureCanvas):
 
-    def __init__(self, model, parent, main_window):
+    def __init__(self, model: PlotModel, parent, main_window):
 
         self.figure = Figure(dpi=main_window.logicalDpiX())
         super().__init__(self.figure)

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -339,8 +339,8 @@ class PlotImage(FigureCanvas):
 
     def wheelEvent(self, event):
 
-        if event.delta() and event.modifiers() == QtCore.Qt.ShiftModifier:
-            numDegrees = event.delta() / 8
+        if event.angleDelta() and event.modifiers() == QtCore.Qt.ShiftModifier:
+            numDegrees = event.angleDelta() / 8
 
             if 24 < self.main_window.zoom + numDegrees < 5001:
                 self.main_window.editZoom(self.main_window.zoom + numDegrees)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -1,12 +1,12 @@
+from __future__ import annotations
 from ast import literal_eval
 from collections import defaultdict
 import copy
 import hashlib
 import itertools
-import os
-from pathlib import Path
 import pickle
 import threading
+from typing import Literal, Tuple
 
 from PySide6.QtWidgets import QItemDelegate, QColorDialog, QLineEdit, QMessageBox
 from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt, QSize, QEvent
@@ -59,6 +59,8 @@ _SCORE_UNITS['damage-energy'] = _ENERGY_UNITS
 _TALLY_VALUES = {'Mean': 'mean',
                  'Std. Dev.': 'std_dev',
                  'Rel. Error': 'rel_err'}
+
+TallyValueType = Literal['mean', 'std_dev', 'rel_err']
 
 
 def hash_file(path):
@@ -386,7 +388,7 @@ class PlotModel:
         """
         Parameters
         ----------
-        view :
+        view : PlotView
             View used to set bounds of the tally data
 
         Returns
@@ -635,7 +637,10 @@ class PlotModel:
 
         return image_data, None, data_min, data_max
 
-    def _create_tally_mesh_image(self, tally, tally_value, scores, nuclides, view=None):
+    def _create_tally_mesh_image(
+            self, tally: openmc.Tally, tally_value: TallyValueType,
+            scores: Tuple[str], nuclides: Tuple[str], view: PlotView = None
+        ):
         # some variables used throughout
         if view is None:
             view = self.currentView

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -700,10 +700,17 @@ class PlotModel:
         data_min = np.min(data)
         data_max = np.max(data)
 
+        # Account for mesh filter translation
+        if mesh_filter.translation is not None:
+            t = mesh_filter.translation
+            origin = (view.origin[0] - t[0], view.origin[1] - t[1], view.origin[2] - t[2])
+        else:
+            origin = view.origin
+
         # Get mesh bins from openmc.lib
         mesh_cpp = openmc.lib.meshes[mesh.id]
         mesh_bins = mesh_cpp.get_plot_bins(
-            origin=view.origin,
+            origin=origin,
             width=(view.width, view.height),
             basis=view.basis,
             pixels=(view.h_res, view.v_res),

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -696,10 +696,6 @@ class PlotModel:
                 selected_scores.append(idx)
         data = _do_op(data[np.array(selected_scores)], tally_value)
 
-        # get dataset's min/max
-        data_min = np.min(data)
-        data_max = np.max(data)
-
         # Account for mesh filter translation
         if mesh_filter.translation is not None:
             t = mesh_filter.translation
@@ -716,10 +712,18 @@ class PlotModel:
             pixels=(view.h_res, view.v_res),
         )
 
+        # Apply volume normalization
+        if view.tallyVolumeNorm:
+            data /= mesh_cpp.volumes
+
         # set image data
         image_data = np.full_like(self.ids, np.nan, dtype=float)
         mask = (mesh_bins >= 0)
         image_data[mask] = data[mesh_bins[mask]]
+
+        # get dataset's min/max
+        data_min = np.min(data)
+        data_max = np.max(data)
 
         return image_data, None, data_min, data_max
 
@@ -911,6 +915,7 @@ class PlotViewIndependent:
         self.tallyDataMax = np.inf
         self.tallyDataLogScale = False
         self.tallyMaskZeroValues = False
+        self.tallyVolumeNorm = False
         self.clipTallyData = False
         self.tallyValue = "Mean"
         self.tallyContours = False

--- a/openmc_plotter/tools.py
+++ b/openmc_plotter/tools.py
@@ -168,33 +168,36 @@ class ExportDataDialog(QtWidgets.QDialog):
             mesh = mesh_filter.mesh
             assert(mesh.n_dimension == 3)
 
-            llc = mesh.lower_left
+            bbox = mesh.bounding_box
+
+            llc = bbox.lower_left
             self.xminBox.setValue(llc[0])
             self.yminBox.setValue(llc[1])
             self.zminBox.setValue(llc[2])
 
-            urc = mesh.upper_right
+            urc = bbox.upper_right
             self.xmaxBox.setValue(urc[0])
             self.ymaxBox.setValue(urc[1])
             self.zmaxBox.setValue(urc[2])
-
-            dims = mesh.dimension
-            self.xResBox.setValue(dims[0])
-            self.yResBox.setValue(dims[1])
-            self.zResBox.setValue(dims[2])
 
             bounds_msg = "Using MeshFilter to set bounds automatically."
             for box in self.bounds_spin_boxes:
                 box.setEnabled(False)
                 box.setToolTip(bounds_msg)
 
-            resolution_msg = "Using MeshFilter to set resolution automatically."
-            self.xResBox.setEnabled(False)
-            self.xResBox.setToolTip(resolution_msg)
-            self.yResBox.setEnabled(False)
-            self.yResBox.setToolTip(resolution_msg)
-            self.zResBox.setEnabled(False)
-            self.zResBox.setToolTip(resolution_msg)
+            dims = mesh.dimension
+            if len(dims) == 3:
+                self.xResBox.setValue(dims[0])
+                self.yResBox.setValue(dims[1])
+                self.zResBox.setValue(dims[2])
+
+                resolution_msg = "Using MeshFilter to set resolution automatically."
+                self.xResBox.setEnabled(False)
+                self.xResBox.setToolTip(resolution_msg)
+                self.yResBox.setEnabled(False)
+                self.yResBox.setToolTip(resolution_msg)
+                self.zResBox.setEnabled(False)
+                self.zResBox.setToolTip(resolution_msg)
 
         else:
             # initialize using the bounds of the current view
@@ -214,14 +217,12 @@ class ExportDataDialog(QtWidgets.QDialog):
 
     def export_data(self):
         # cache current and active views
-        cv = self.model.currentView
         av = self.model.activeView
         try:
             # export the tally data
             self._export_data()
         finally:
-            #always reset to the original view
-            self.model.currentView = cv
+            # always reset to the original view
             self.model.activeView = av
             self.model.makePlot()
 

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ kwargs = {
     ],
 
     # Dependencies
-    'python_requires': '>=3.6',
+    'python_requires': '>=3.8',
     'install_requires': [
-        'openmc>0.12.2', 'numpy', 'matplotlib', 'PySide6'
+        'openmc>0.14.0', 'numpy', 'matplotlib', 'PySide6'
     ],
     'extras_require': {
         'test' : ['pytest', 'pytest-qt'],


### PR DESCRIPTION
Right now the mesh tally plotting capability in the plotter only works with `RegularMesh` tallies. This PR generalizes the mesh tally capability to work for any mesh type by leveraging the new `get_plot_bins` method introduced in openmc-dev/openmc#2854. Here's an example showing a spherical mesh tally plotted:
![image](https://github.com/openmc-dev/plotter/assets/743095/203f0e66-a39e-41e3-b84a-a456321dd36b)
