### PR TITLE
Immediate updates to score selection for tally plotting

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -505,15 +505,9 @@ class TallyDock(PlotterDock):
             self.score_map = {}
             self.scoresListWidget.clear()
 
-            sorted_scores = sorted(tally.scores)
-            # always put total first if present
-            if 'total' in sorted_scores:
-                idx = sorted_scores.index('total')
-                sorted_scores.insert(0, sorted_scores.pop(idx))
-
-            for score in sorted_scores:
+            for score in tally.scores:
                 ql = QListWidgetItem()
-                ql.setText(score.capitalize())
+                ql.setText(score)
                 ql.setCheckState(QtCore.Qt.Unchecked)
                 if not spatial_filters:
                     ql.setFlags(QtCore.Qt.ItemIsUserCheckable)
@@ -635,14 +629,6 @@ class TallyDock(PlotterDock):
                     score_box.setFlags(QtCore.Qt.ItemIsUserCheckable |
                                        QtCore.Qt.ItemIsEnabled |
                                        QtCore.Qt.ItemIsSelectable)
-            elif 'total' in applied_scores:
-                self.model.appliedScores = ('total',)
-                # if total is selected, disable all other scores
-                for score, score_box in self.score_map.items():
-                    if score != 'total':
-                        score_box.setFlags(QtCore.Qt.ItemIsUserCheckable)
-                        score_box.setToolTip(
-                            "De-select 'total' to enable other scores")
             else:
                 # get units of applied scores
                 selected_units = _SCORE_UNITS.get(


### PR DESCRIPTION
Right now when you are plotting tallies, if your tally has multiple scores and you want to select a different one, you have to deselect the currently selected one, hit apply, and then select a new one. The changes in this PR make it so that when you deselect a score, it immediately updates which checkboxes are active so that you don't have to hit apply in between. I also changed some of the special logic around the 'total' score which, in my opinion, just complicated things more.