### PR TITLE
Add checkbox for reversing colormap

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -776,6 +776,11 @@ class ColorForm(QWidget):
         cmap_connector = partial(main_window.editTallyDataColormap)
         self.colormapBox.currentTextChanged[str].connect(cmap_connector)
 
+        # Color map reverse
+        self.reverseCmapBox = QCheckBox()
+        reverse_connector = partial(main_window.toggleReverseCmap)
+        self.reverseCmapBox.stateChanged.connect(reverse_connector)
+
         # Data indicator line check box
         self.dataIndicatorCheckBox = QCheckBox()
         data_indicator_connector = partial(
@@ -831,6 +836,7 @@ class ColorForm(QWidget):
         self.layout.addRow("Visible:", self.visibilityBox)
         self.layout.addRow("Alpha: ", self.alphaBox)
         self.layout.addRow("Colormap: ", self.colormapBox)
+        self.layout.addRow("Reverse colormap: ", self.reverseCmapBox)
         self.layout.addRow("Data Indicator: ", self.dataIndicatorCheckBox)
         self.layout.addRow("Custom Min/Max: ", self.userMinMaxBox)
         self.layout.addRow("Min: ", self.minBox)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1004,6 +1004,10 @@ class MainWindow(QMainWindow):
         if apply:
             self.applyChanges()
 
+    def toggleReverseCmap(self, state):
+        av = self.model.activeView
+        av.tallyDataReverseCmap = bool(state)
+
     def updateTallyMinMax(self):
         self.tallyDock.updateMinMax()
 

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -587,6 +587,10 @@ class PlotImage(FigureCanvas):
 
             norm = SymLogNorm(1E-30) if cv.tallyDataLogScale else None
 
+            cmap = cv.tallyDataColormap
+            if cv.tallyDataReverseCmap:
+                cmap += '_r'
+
             if cv.tallyContours:
                 # parse the levels line
                 levels = self.parseContoursLine(cv.tallyContourLevels)
@@ -594,14 +598,14 @@ class PlotImage(FigureCanvas):
                                                    origin='image',
                                                    levels=levels,
                                                    alpha=cv.tallyDataAlpha,
-                                                   cmap=cv.tallyDataColormap,
+                                                   cmap=cmap,
                                                    norm=norm,
                                                    extent=extents)
 
             else:
                 self.tally_image = self.ax.imshow(image_data,
                                                   alpha=cv.tallyDataAlpha,
-                                                  cmap=cv.tallyDataColormap,
+                                                  cmap=cmap,
                                                   norm=norm,
                                                   extent=extents)
             # add colorbar

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -923,6 +923,7 @@ class PlotViewIndependent:
 
         # Tally Viz Settings
         self.tallyDataColormap = 'Spectral'
+        self.tallyDataReverseCmap = False
         self.tallyDataVisible = True
         self.tallyDataAlpha = 1.0
         self.tallyDataIndicator = False


### PR DESCRIPTION
When plotting tally data, we provide the full list of colormaps from matplotlib, but there are also reversed versions that are not accessible currently. Sometimes, it is desirable to use the reversed version. For example, the diverging colormap "RdBu" has small values as red and large values as blue. If you want red to mean "hot" and blue to mean "cold", the reversed version "RdBu_r" comes in handy.

This PR simply adds a new checkbox to use the reversed version of the colormap.