### PR TITLE
Improve performance for large models with DomainViewDict

### DIFF
--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1042,7 +1042,7 @@ class MainWindow(QMainWindow):
             dlg.setCurrentColor(QtGui.QColor.fromRgb(*current_color))
         if dlg.exec():
             new_color = dlg.currentColor().getRgb()[:3]
-            domain[id].color = new_color
+            domain.set_color(id, new_color)
 
         self.applyChanges()
 
@@ -1052,7 +1052,7 @@ class MainWindow(QMainWindow):
         else:
             domain = self.model.activeView.materials
 
-        domain[id].masked = bool(state)
+        domain.set_masked(id, bool(state))
         self.applyChanges()
 
     def toggleDomainHighlight(self, state, kind, id):
@@ -1061,7 +1061,7 @@ class MainWindow(QMainWindow):
         else:
             domain = self.model.activeView.materials
 
-        domain[id].highlight = bool(state)
+        domain.set_highlight(id, bool(state))
         self.applyChanges()
 
     # Helper methods:

--- a/openmc_plotter/plot_colors.py
+++ b/openmc_plotter/plot_colors.py
@@ -1,10 +1,4 @@
-
 import numpy as np
-
-
-# for consistent, but random, colors
-def reset_seed():
-    np.random.seed(10)
 
 
 def random_rgb():

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -796,8 +796,8 @@ class ViewParam(openmc.lib.plot._PlotBase):
         self.origin = origin
         self.width = width
         self.height = height
-        self.h_res = 1000
-        self.v_res = 1000
+        self.h_res = 100
+        self.v_res = 100
         self.basis = 'xy'
         self.color_overlaps = False
 
@@ -1050,18 +1050,17 @@ class PlotView:
             num_domain = len(openmc.lib.cells)
             get_id = openmc.lib.core._dll.openmc_cell_get_id
             get_name = openmc.lib.core._dll.openmc_cell_get_name
-            domains = DEFAULT_CELL_DOMAIN_VIEW
         elif domain_type == 'material':
             num_domain = len(openmc.lib.materials)
             get_id = openmc.lib.core._dll.openmc_material_get_id
             get_name = openmc.lib.core._dll.openmc_material_get_name
-            domains = DEFAULT_MATERIAL_DOMAIN_VIEW
 
         # Sample default colors for each domain
         colors = rng.randint(256, size=(num_domain, 3))
 
         domain_id_c = c_int32()
         name_c = c_char_p()
+        defaults = {}
         for i, color in enumerate(colors):
             # Get ID and name for each domain
             get_id(i, domain_id_c)
@@ -1070,15 +1069,15 @@ class PlotView:
             name = name_c.value.decode()
 
             # Create default domain view for this domain
-            domains[domain_id] = DomainView(domain_id, name, color)
+            defaults[domain_id] = DomainView(domain_id, name, color)
 
         # always add void to a material domain at the end
         if domain_type == 'material':
             void_id = _VOID_REGION
-            domains[void_id] = DomainView(void_id, "VOID", (255, 255, 255),
+            defaults[void_id] = DomainView(void_id, "VOID", (255, 255, 255),
                                           False, False)
 
-        return DomainViewDict(domain_type)
+        return DomainViewDict(defaults)
 
     def adopt_plotbase(self, view):
         """
@@ -1098,37 +1097,36 @@ class PlotView:
         self.basis = view.basis
 
 
-# To avoid deepcopying the default domain view for every single cell/material,
-# we keep a global dictionary that gets populated at startup. Further domain
-# view customizations are saved as modifications to the default ones
-DEFAULT_CELL_DOMAIN_VIEW = {}
-DEFAULT_MATERIAL_DOMAIN_VIEW = {}
-
-
 class DomainViewDict(dict):
-    """Dictionary of domain ID to DomainView objects, backed by global dict
+    """Dictionary of domain ID to DomainView objects with shared defaults
 
     When the active/current view changes in the plotter, this dictionary gets
     deepcopied. To avoid the dictionary being huge for models with lots of
-    cells/materials, default DomainView objects are stored in global
-    dictionaries and the key/value pairs in this dictionary represent
-    modifications to the default pairs. When an item is looked up, if there is
-    no locally modified version we pull the value from the global dictionary.
+    cells/materials, defaults are stored separately and the key/value pairs in
+    this dictionary represent modifications to the default pairs. When an item
+    is looked up, if there is no locally modified version we pull the value from
+    the defaults dictionary.
 
     """
-    def __init__(self, domain_type: str):
-        self.domain_type = domain_type
+    def __init__(self, defaults: dict):
+        self.defaults = defaults
 
     def __getitem__(self, key) -> DomainView:
         if key in self:
             return super().__getitem__(key)
         else:
-            # If key is not present, default to pulling the value from the
-            # global dictionary
-            if self.domain_type == 'cell':
-                return DEFAULT_CELL_DOMAIN_VIEW[key]
-            else:
-                return DEFAULT_MATERIAL_DOMAIN_VIEW[key]
+            # If key is not present, pull it from the defaults
+            return self.defaults[key]
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        obj = cls.__new__(cls)
+        memo[id(self)] = obj
+        for key, value in self.items():
+            obj[key] = copy.deepcopy(value)
+        # Shallow copy the defaults dictionary
+        obj.defaults = self.defaults
+        return obj
 
     def set_color(self, key: int, color):
         domain = self[key]

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -796,8 +796,8 @@ class ViewParam(openmc.lib.plot._PlotBase):
         self.origin = origin
         self.width = width
         self.height = height
-        self.h_res = 100
-        self.v_res = 100
+        self.h_res = 1000
+        self.v_res = 1000
         self.basis = 'xy'
         self.color_overlaps = False
 


### PR DESCRIPTION
If you run the plotter on a model with lots of cells (the ITER E-lite model, for example), it spends a lot of time copying data around unnecessarily. The crux of the issue is this line:
https://github.com/openmc-dev/plotter/blob/e772fb9ba55532ea984c4eb529c7fbf2982268f0/openmc_plotter/plotmodel.py#L321

which deepcopies the entire `PlotView` object. This object holds dictionaries called `cells` and `materials` that map cell and material IDs to `DomainView` objects (one for each cell and material that appears in the model). When I plot the ITER E-lite model, which has >300k cells, those deepcopies take about 12 seconds on my machine, which means that every time I update the plot view, there is a lag of 12 seconds even when the plot resolution is super low.

This PR makes a fairly easy fix to this problem, which is to store a global dictionary that holds the default `DomainView` view settings that are created at startup *separately* from the `PlotView` object itself. If you make a modification to the domain view (e.g., changing the color of a material), it does get stored as part the `PlotView` object and will get copied around, but the default domain views remain untouched and don't get copied.