### PR TITLE
Replace Colorbar.draw_all with Figure.draw_without_rendering

### DIFF
--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -719,7 +719,7 @@ class PlotImage(FigureCanvas):
     def updateColorMap(self, colormap_name, property_type):
         if self.colorbar and property_type == self.model.activeView.colorby:
             self.image.set_cmap(colormap_name)
-            self.colorbar.draw_all()
+            self.figure.draw_without_rendering()
             self.draw()
 
     def updateColorMinMax(self, property_type):
@@ -729,7 +729,7 @@ class PlotImage(FigureCanvas):
             self.colorbar.mappable.set_clim(*clim)
             self.data_indicator.set_data(clim[:2],
                                          (0.0, 0.0))
-            self.colorbar.draw_all()
+            self.figure.draw_without_rendering()
             self.draw()
 
 


### PR DESCRIPTION
The `draw_all` method of `Colorbar` was deprecated in [matplotlib 3.6](https://matplotlib.org/3.6.3/api/colorbar_api.html#matplotlib.colorbar.Colorbar.draw_all) and has since been removed. The deprecation note suggests replacing with `figure.draw_without_rendering`. This currently causes an error if you do a temperature/density plot with a recent version of matplotlib.