### PR TITLE
Make items in filter list auto tristate

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -404,7 +404,8 @@ class TallyDock(PlotterDock):
                     0, "Only tallies with spatial filters are viewable.")
             else:
                 filter_item.setFlags(
-                    filter_item.flags() | QtCore.Qt.ItemIsUserCheckable)
+                    filter_item.flags() | QtCore.Qt.ItemIsUserCheckable |
+                    QtCore.Qt.ItemIsAutoTristate)
             filter_item.setCheckState(0, QtCore.Qt.Unchecked)
 
             # all mesh bins are selected by default and not shown in the dock

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -1317,7 +1317,7 @@ class DomainTableModel(QAbstractTableModel):
                 self.domains.set_masked(key, Qt.CheckState(value) == Qt.Checked)
         elif column == HIGHLIGHT:
             if role == Qt.CheckStateRole:
-                self.domains.set_highlight(Qt.CheckState(value) == Qt.Checked)
+                self.domains.set_highlight(key, Qt.CheckState(value) == Qt.Checked)
 
         self.dataChanged.emit(index, index)
         return True


### PR DESCRIPTION
If you have a mesh tally with other filters on top, right now it's not possible to pick out specific bins from those other filters. After digging into this a while, I realized that the problem was that the top-level treewidget items were not being set to "auto tristate", which allows them to be partially checked based on the state of the child items. With this change, now you can select bins for these filters freely. In my particular use case, I'm combining a material filter with a mesh filter and want to plot the mesh results restricted to a particular material.