### PR TITLE
Prevent potential issue with shortcutOverlay not being recognized

### DIFF
--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -83,7 +83,7 @@ class MainWindow(QMainWindow):
         # Dock
         self.dock = DomainDock(self.model, self.font_metric, self)
         self.dock.setObjectName("Domain Options Dock")
-        self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.dock)
+        self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, self.dock)
 
         # Tally Dock
         self.tallyDock = TallyDock(self.model, self.font_metric, self)
@@ -98,6 +98,10 @@ class MainWindow(QMainWindow):
         # Tools
         self.exportDataDialog = ExportDataDialog(self.model, self.font_metric, self)
 
+        # Keyboard overlay
+        self.shortcutOverlay = ShortcutsOverlay(self)
+        self.shortcutOverlay.hide()
+
         # Restore Window Settings
         self.restoreWindowSettings()
 
@@ -109,10 +113,6 @@ class MainWindow(QMainWindow):
         self.coord_label = QLabel()
         self.statusBar().addPermanentWidget(self.coord_label)
         self.coord_label.hide()
-
-        # Keyboard overlay
-        self.shortcutOverlay = ShortcutsOverlay(self)
-        self.shortcutOverlay.hide()
 
         # Load Plot
         self.statusBar().showMessage('Generating Plot...')
@@ -1077,7 +1077,7 @@ class MainWindow(QMainWindow):
         settings = QtCore.QSettings()
 
         self.resize(settings.value("mainWindow/Size",
-                                   QtCore.QSize(800, 600)))
+                                   QtCore.QSize(1200, 800)))
         self.move(settings.value("mainWindow/Position",
                                  QtCore.QPoint(100, 100)))
         self.restoreState(settings.value("mainWindow/State"))


### PR DESCRIPTION
When the plotter is loading up, some previous settings are loaded via the `QSettings` class:
https://github.com/openmc-dev/plotter/blob/d7ac96ac127f755f87b40b1fa96f008ff3818192/openmc_plotter/main_window.py#L1079-L1083

We've [gotten](https://openmc.discourse.group/t/openmc-plotter-aborts-on-launch-attributeerror-mainwindow-object-has-no-attribute-shortcutoverlay/4158) [reports](https://openmc.discourse.group/t/openmc-plotter-error-object-has-no-attribute-shortcutoverlay/4344) [from](https://openmc.discourse.group/t/install-on-macos-from-conda/4191) users recently that the call to `restoreState` results in an exception as follows:
```
File “.../lib/python3.11/site-packages/openmc_plotter/main_window.py”, line 1158, in resizeEvent
if self.shortcutOverlay.isVisible():
^^^^^^^^^^^^^^^^^^^^
AttributeError: ‘MainWindow’ object has no attribute ‘shortcutOverlay’
```
I suspect this might actually be a bug in PySide6, but nevertheless the changes in this PR should hopefully prevent problems by moving the creation of the `shortcutOverlay` attribute to before we call `restoreState`.