### PR TITLE
Image origin crosshair

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -112,11 +112,17 @@ class DomainDock(PlotterDock):
                                  dimension=2)
         self.zOrBox.valueChanged.connect(zbox_connector)
 
+        self.orCrossHairBox = QCheckBox()
+        crosshair_connector = partial(self.main_window.toggleOriginCrosshair, apply=False)
+        self.orCrossHairBox.setCheckState(QtCore.Qt.Checked if self.model.currentView.originCrosshair else QtCore.Qt.Unchecked)
+        self.orCrossHairBox.stateChanged.connect(crosshair_connector)
+
         # Origin Form Layout
         self.orLayout = QFormLayout()
         self.orLayout.addRow('X:', self.xOrBox)
         self.orLayout.addRow('Y:', self.yOrBox)
         self.orLayout.addRow('Z:', self.zOrBox)
+        self.orLayout.addRow('Crosshair:', self.orCrossHairBox)
         self.orLayout.setLabelAlignment(QtCore.Qt.AlignLeft)
         self.orLayout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
 

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -828,6 +828,12 @@ class MainWindow(QMainWindow):
     def editSingleOrigin(self, value, dimension):
         self.model.activeView.origin[dimension] = value
 
+    def toggleOriginCrosshair(self, state, apply=False):
+        self.model.activeView.originCrosshair = bool(state)
+
+        if apply:
+            self.applyChanges()
+
     def editPlotAlpha(self, value):
         self.model.activeView.domainAlpha = value
 

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -648,6 +648,11 @@ class PlotImage(FigureCanvas):
         self.ax.dataLim.y0 = data_bounds[2]
         self.ax.dataLim.y1 = data_bounds[3]
 
+        if cv.originCrosshair:
+            self.ax.plot(cv.origin[self.main_window.xBasis],
+                        cv.origin[self.main_window.yBasis],
+                        'b+')
+
         self.draw()
         return "Done"
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -872,6 +872,8 @@ class PlotViewIndependent:
         Alpha value of the geometry plot
     plotVisibile : bool
         Controls visibility of geometry
+    originCrosshair: bool
+        Controls visibility of origin crosshair
     outlines: bool
         Controls visibility of geometry outlines
     tallyDataColormap : str
@@ -915,6 +917,7 @@ class PlotViewIndependent:
         self.overlap_color = (255, 0, 0)
         self.domainAlpha = 1.0
         self.domainVisible = True
+        self.originCrosshair = False
         self.outlines = False
         self.colormaps = {'temperature': 'Oranges', 'density': 'Greys'}
         # set defaults for color dialog


### PR DESCRIPTION
When examining a model, one may be interested in a specific Cartesian location. The origin can be set to a specific easily enough, but that location can be hard to pinpoint with the cursor -- the only option at the moment. 

This PR adds an option to display the origin of the image as a crosshair to make identification easier.