### PR TITLE
Add an CML option to clear the application cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ can be used to generate images from the command line without opening the plotter
 ```console
 $ openmc-plotter -b view1.pltvw view1.pltvw view1.pltvw
 ```
+## Troubleshooting
+
+Updates to the plotter can result in stale references to deprecated features. For example, it's possible that something like the following may appear after an update:
+
+```
+AttributeError: 'MainWindow' object has no attribute 'shortcutOverlay'
+```
+
+To address this, the application settings can be cleared, the plotter can be started with the `--clear-config` (or `-c`) to reset the application's settings cache on startup.
+
+```bash
+$ openmc-plotter --clear-cache
+```
 
 ## Features
 

--- a/openmc_plotter/__main__.py
+++ b/openmc_plotter/__main__.py
@@ -28,6 +28,8 @@ def main():
                     'XML files (default is current dir)')
     ap.add_argument('-b', '--batch-mode', nargs='+', default=False,
                     help='View files used to generate plots in batch mode')
+    ap.add_argument('-c', '--clear-config', action='store_true', default=False,
+                    help='Clear the Qt application configuration settings')
 
     args = ap.parse_args()
 
@@ -44,6 +46,10 @@ def run_app(user_args):
     app.setApplicationName("OpenMC Plot Explorer")
     app.setWindowIcon(QtGui.QIcon(path_icon))
     app.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus, True)
+
+    if user_args.clear_config:
+        settings = QtCore.QSettings()
+        settings.clear()
 
     splash_pix = QtGui.QPixmap(path_splash)
     splash = QSplashScreen(splash_pix, QtCore.Qt.WindowStaysOnTopHint)


### PR DESCRIPTION
A few users have reached out about problems related to crashed caused by the Qt application configuration state, which manifests itself in a few ways. See:

  - #128 
  - https://openmc.discourse.group/t/openmc-plotter-error-object-has-no-attribute-shortcutoverlay/4344
  - https://openmc.discourse.group/t/openmc-plotter-aborts-on-launch-attributeerror-mainwindow-object-has-no-attribute-shortcutoverlay/4158

 Often the answer to these solutions is to remove the plotter configuration file manually (usually in `~/.config/OpenMC`). The `QtSettings` allows one to clear this cache programmatically, so rather than having users taking this step manually this PR provides an option to do so with a `--clear-cache` flag that can be passed via the CML to the plotter application. 