### PR TITLE
Use faster algorithm for generating contours

### DIFF
--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -600,7 +600,8 @@ class PlotImage(FigureCanvas):
                                                    alpha=cv.tallyDataAlpha,
                                                    cmap=cmap,
                                                    norm=norm,
-                                                   extent=extents)
+                                                   extent=extents,
+                                                   algorithm='serial')
 
             else:
                 self.tally_image = self.ax.imshow(image_data,
@@ -673,7 +674,8 @@ class PlotImage(FigureCanvas):
             colors='k',
             linestyles='solid',
             levels=np.unique(mesh_bins),
-            extent=data_bounds
+            extent=data_bounds,
+            algorithm='serial'
         )
 
     def plotSourceSites(self):
@@ -712,7 +714,8 @@ class PlotImage(FigureCanvas):
                                             colors='k',
                                             linestyles='solid',
                                             levels=levels,
-                                            extent=data_bounds)
+                                            extent=data_bounds,
+                                            algorithm='serial')
 
     @staticmethod
     def parseContoursLine(line):


### PR DESCRIPTION
The [`Axes.contour` method](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contour.html) from matplotlib uses ContourPy under the hood, and there are several algorithms that are available. I noticed that the default one that matplotlib uses ("mpl2014") is a bit older than the default one for ContourPy ("serial"). This PR explicitly uses the "serial" algorithm whenever we call `ax.contour`, which in my testing results in a 2x speedup for generating contours.

The problem where I noticed this is as shown below. I was looking at a mesh annotation for a 80x80x80 mesh, and generating the mesh annotation took 25 seconds. Switching to the "serial" algorithm cut that down to 13 seconds.
<img src="https://github.com/user-attachments/assets/4f8ddcf6-9f7f-4737-bbc7-afe8b6f6f0ca" width="600px" />
