### PR TITLE
Ability to show outlines by cell or material independent of "Color by"

### DIFF
--- a/openmc_plotter/docks.py
+++ b/openmc_plotter/docks.py
@@ -221,8 +221,10 @@ class DomainDock(PlotterDock):
             self.main_window.editPlotVisibility)
 
         # Outlines
-        self.outlinesBox = QCheckBox(self)
-        self.outlinesBox.stateChanged.connect(self.main_window.toggleOutlines)
+        self.outlinesCellBox = QCheckBox(self)
+        self.outlinesCellBox.stateChanged.connect(self.main_window.toggleOutlinesCell)
+        self.outlinesMatBox = QCheckBox(self)
+        self.outlinesMatBox.stateChanged.connect(self.main_window.toggleOutlinesMat)
 
         # Basis
         self.basisBox = QComboBox(self)
@@ -247,7 +249,8 @@ class DomainDock(PlotterDock):
         self.opLayout.addRow('Universe Level:', self.universeLevelBox)
         self.opLayout.addRow('Plot alpha:', self.domainAlphaBox)
         self.opLayout.addRow('Visible:', self.visibilityBox)
-        self.opLayout.addRow('Outlines:', self.outlinesBox)
+        self.opLayout.addRow('Cell Outlines:', self.outlinesCellBox)
+        self.opLayout.addRow('Material Outlines:', self.outlinesMatBox)
         self.opLayout.addRow(self.colorOptionsButton)
         self.opLayout.setLabelAlignment(QtCore.Qt.AlignLeft)
         self.opLayout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
@@ -331,7 +334,8 @@ class DomainDock(PlotterDock):
         self.visibilityBox.setChecked(self.model.activeView.domainVisible)
 
     def updateOutlines(self):
-        self.outlinesBox.setChecked(self.model.activeView.outlines)
+        self.outlinesCellBox.setChecked(self.model.activeView.outlinesCell)
+        self.outlinesMatBox.setChecked(self.model.activeView.outlinesMat)
 
     def updateBasis(self):
         self.basisBox.setCurrentText(self.model.activeView.basis)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -375,7 +375,7 @@ class MainWindow(QMainWindow):
         self.outlineAct.setToolTip('Display Cell/Material Boundaries')
         self.outlineAct.setStatusTip('Toggle display of domain '
                                      'outlines when enabled')
-        outline_connector = partial(self.toggleOutlines, apply=True)
+        outline_connector = partial(self.toggleOutlinesCell, apply=True)
         self.outlineAct.toggled.connect(outline_connector)
         self.editMenu.addAction(self.outlineAct)
 
@@ -444,7 +444,7 @@ class MainWindow(QMainWindow):
 
         self.maskingAction.setChecked(self.model.currentView.masking)
         self.highlightingAct.setChecked(self.model.currentView.highlighting)
-        self.outlineAct.setChecked(self.model.currentView.outlines)
+        self.outlineAct.setChecked(self.model.currentView.outlinesCell)
         self.overlapAct.setChecked(self.model.currentView.color_overlaps)
 
         num_previous_views = len(self.model.previousViews)
@@ -877,8 +877,15 @@ class MainWindow(QMainWindow):
     def editPlotVisibility(self, value):
         self.model.activeView.domainVisible = bool(value)
 
-    def toggleOutlines(self, value, apply=False):
-        self.model.activeView.outlines = bool(value)
+    def toggleOutlinesCell(self, value, apply=False):
+        self.model.activeView.outlinesCell = bool(value)
+        self.dock.updateOutlines()
+
+        if apply:
+            self.applyChanges()
+
+    def toggleOutlinesMat(self, value, apply=False):
+        self.model.activeView.outlinesMat = bool(value)
         self.dock.updateOutlines()
 
         if apply:

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -549,6 +549,11 @@ class MainWindow(QMainWindow):
 
         if saved['version'] == self.model.version:
             self.model.activeView = saved['current']
+            # Handle backward compatibility for outline attributes
+            if not hasattr(self.model.activeView, 'outlinesCell'):
+                self.model.activeView.outlinesCell = False
+            if not hasattr(self.model.activeView, 'outlinesMat'):
+                self.model.activeView.outlinesMat = False
             self.dock.updateDock()
             self.colorDialog.updateDialogValues()
             self.applyChanges()

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -705,17 +705,28 @@ class PlotImage(FigureCanvas):
     def add_outlines(self):
         cv = self.model.currentView
         # draw outlines as isocontours
-        if cv.outlines:
+        if cv.outlinesCell or cv.outlinesMat:
             # set data extents for automatic reporting of pointer location
             data_bounds = self.current_view_data_bounds()
-            levels = np.unique(self.model.ids)
-            self.contours = self.ax.contour(self.model.ids,
-                                            origin='upper',
-                                            colors='k',
-                                            linestyles='solid',
-                                            levels=levels,
-                                            extent=data_bounds,
-                                            algorithm='serial')
+            if cv.outlinesCell:
+                levels = np.unique(self.model.cell_ids)
+                self.ax.contour(self.model.cell_ids,
+                                origin='upper',
+                                colors='k',
+                                linestyles='solid',
+                                levels=levels,
+                                extent=data_bounds,
+                                algorithm='serial')
+            if cv.outlinesMat:
+                levels = np.unique(self.model.mat_ids)
+                self.ax.contour(self.model.mat_ids,
+                                origin='upper',
+                                colors='k',
+                                linestyles='solid',
+                                levels=levels,
+                                extent=data_bounds,
+                                algorithm='serial')
+
 
     @staticmethod
     def parseContoursLine(line):

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -991,6 +991,15 @@ class PlotViewIndependent:
         self.tallyContours = False
         self.tallyContourLevels = ""
 
+    def __setstate__(self, state):
+        """Handle backward compatibility when unpickling old views"""
+        self.__dict__.update(state)
+        # Add missing attributes from older versions
+        if not hasattr(self, 'outlinesCell'):
+            self.outlinesCell = False
+        if not hasattr(self, 'outlinesMat'):
+            self.outlinesMat = False
+
     def getDataLimits(self):
         return self.data_minmax
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -919,8 +919,10 @@ class PlotViewIndependent:
         Alpha value of the geometry plot
     plotVisibile : bool
         Controls visibility of geometry
-    outlines: bool
-        Controls visibility of geometry outlines
+    outlinesCell : bool
+        Controls visibility of cell outlines
+    outlinesMat : bool
+        Controls visibility of material outlines
     tallyDataColormap : str
         Name of the colormap used for tally data
     tallyDataVisible : bool
@@ -962,7 +964,8 @@ class PlotViewIndependent:
         self.overlap_color = (255, 0, 0)
         self.domainAlpha = 1.0
         self.domainVisible = True
-        self.outlines = False
+        self.outlinesCell = False
+        self.outlinesMat = False
         self.colormaps = {'temperature': 'Oranges', 'density': 'Greys'}
         # set defaults for color dialog
         self.data_minmax = {prop: (0.0, 0.0) for prop in _MODEL_PROPERTIES}


### PR DESCRIPTION
Title pretty much says it all: this PR changes the interface so that we now have two checkboxes for outlines, one for cell outlines and one for material outlines. This allows outlines to be shown independent of the coloring, so for example you can color by material while showing cell outlines.