### PR TITLE
Make plot generation asynchronous to keep the UI responsive

### DIFF
--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -56,8 +56,13 @@ class MainWindow(QMainWindow):
         self.model_path = Path(model_path)
         self.threads = threads
         self.default_res = resolution
+        self.model = None
         self.plot_manager = None
-        self.busyIndicator = None
+        self.busyIndicator = QProgressBar()
+        self.busyIndicator.setRange(0, 0)
+        self.busyIndicator.setMaximumWidth(self.font_metric.averageCharWidth() * 12)
+        self.busyIndicator.setMaximumHeight(self.font_metric.height())
+        self.busyIndicator.hide()
 
     def loadGui(self, use_settings_pkl=True):
 
@@ -115,11 +120,6 @@ class MainWindow(QMainWindow):
         self.coord_label = QLabel()
         self.statusBar().addPermanentWidget(self.coord_label)
         self.coord_label.hide()
-        self.busyIndicator = QProgressBar()
-        self.busyIndicator.setRange(0, 0)
-        self.busyIndicator.setMaximumWidth(self.font_metric.averageCharWidth() * 12)
-        self.busyIndicator.setMaximumHeight(self.font_metric.height())
-        self.busyIndicator.hide()
         self.statusBar().addPermanentWidget(self.busyIndicator)
 
         self.plot_manager = self.model.plot_manager
@@ -485,7 +485,7 @@ class MainWindow(QMainWindow):
     # Menu and shared methods
     def loadModel(self, reload=False, use_settings_pkl=True):
         if reload:
-            if hasattr(self, "plot_manager"):
+            if self.plot_manager is not None:
                 self.plot_manager.wait_for_idle()
             self.resetModels()
         else:
@@ -1197,7 +1197,7 @@ class MainWindow(QMainWindow):
             self.shortcutOverlay.resize(self.width(), self.height())
 
     def closeEvent(self, event):
-        if hasattr(self, "plot_manager"):
+        if self.plot_manager is not None:
             self.plot_manager.wait_for_idle()
             self.plot_manager.shutdown()
         settings = QtCore.QSettings()
@@ -1218,16 +1218,15 @@ class MainWindow(QMainWindow):
         self.requestPlotUpdate()
 
     def requestPlotUpdate(self, view=None):
+        if self.model is None:
+            return None
         if self.plot_manager is None:
-            if hasattr(self, "model"):
-                self.plot_manager = self.model.plot_manager
-                self.plot_manager.plot_started.connect(self._on_plot_started)
-                self.plot_manager.plot_queued.connect(self._on_plot_queued)
-                self.plot_manager.plot_finished.connect(self._on_plot_finished)
-                self.plot_manager.plot_error.connect(self._on_plot_error)
-                self.plot_manager.plot_idle.connect(self._on_plot_idle)
-            else:
-                return None
+            self.plot_manager = self.model.plot_manager
+            self.plot_manager.plot_started.connect(self._on_plot_started)
+            self.plot_manager.plot_queued.connect(self._on_plot_queued)
+            self.plot_manager.plot_finished.connect(self._on_plot_finished)
+            self.plot_manager.plot_error.connect(self._on_plot_error)
+            self.plot_manager.plot_idle.connect(self._on_plot_idle)
         if view is None:
             view = self.model.activeView
         view_snapshot = copy.deepcopy(view)
@@ -1240,13 +1239,12 @@ class MainWindow(QMainWindow):
         return request_id
 
     def waitForPlotIdle(self, timeout_ms=None):
-        if hasattr(self, "plot_manager"):
+        if self.plot_manager is not None:
             return self.plot_manager.wait_for_idle(timeout_ms)
         return True
 
     def _on_plot_started(self, request_id):
-        if self.busyIndicator is not None:
-            self.busyIndicator.show()
+        self.busyIndicator.show()
         self.statusBar().showMessage('Generating Plot...')
 
     def _on_plot_queued(self, request_id):
@@ -1269,8 +1267,7 @@ class MainWindow(QMainWindow):
         msg_box.exec()
 
     def _on_plot_idle(self):
-        if self.busyIndicator is not None:
-            self.busyIndicator.hide()
+        self.busyIndicator.hide()
         self.statusBar().showMessage('')
 
     def saveSettings(self):

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1204,7 +1204,7 @@ class MainWindow(QMainWindow):
 
     def closeEvent(self, event):
         if self.plot_manager is not None:
-            self.plot_manager.wait_for_idle()
+            self.plot_manager.wait_for_idle(timeout_ms=250)
             self.plot_manager.shutdown()
         settings = QtCore.QSettings()
         settings.setValue("mainWindow/Size", self.size())

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -58,11 +58,6 @@ class MainWindow(QMainWindow):
         self.default_res = resolution
         self.model = None
         self.plot_manager = None
-        self.busyIndicator = QProgressBar()
-        self.busyIndicator.setRange(0, 0)
-        self.busyIndicator.setMaximumWidth(self.font_metric.averageCharWidth() * 12)
-        self.busyIndicator.setMaximumHeight(self.font_metric.height())
-        self.busyIndicator.hide()
 
     def loadGui(self, use_settings_pkl=True):
 
@@ -120,6 +115,11 @@ class MainWindow(QMainWindow):
         self.coord_label = QLabel()
         self.statusBar().addPermanentWidget(self.coord_label)
         self.coord_label.hide()
+        self.busyIndicator = QProgressBar()
+        self.busyIndicator.setRange(0, 0)
+        self.busyIndicator.setMaximumWidth(self.font_metric.averageCharWidth() * 12)
+        self.busyIndicator.setMaximumHeight(self.font_metric.height())
+        self.busyIndicator.hide()
         self.statusBar().addPermanentWidget(self.busyIndicator)
 
         self.plot_manager = self.model.plot_manager

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1217,13 +1217,6 @@ class MainWindow(QMainWindow):
     def requestPlotUpdate(self, view=None):
         if self.model is None:
             return
-        if self.plot_manager is None:
-            self.plot_manager = self.model.plot_manager
-            self.plot_manager.plot_started.connect(self._on_plot_started)
-            self.plot_manager.plot_queued.connect(self._on_plot_queued)
-            self.plot_manager.plot_finished.connect(self._on_plot_finished)
-            self.plot_manager.plot_error.connect(self._on_plot_error)
-            self.plot_manager.plot_idle.connect(self._on_plot_idle)
         if view is None:
             view = self.model.activeView
         view_snapshot = copy.deepcopy(view)
@@ -1246,12 +1239,10 @@ class MainWindow(QMainWindow):
         return True
 
     def _on_plot_started(self):
-        if hasattr(self, "plotIm") and self.plotIm is not None:
-            self.plotIm.showUpdatingOverlay("Generating Plot...")
+        self.plotIm.showUpdatingOverlay("Generating Plot...")
 
     def _on_plot_queued(self):
-        if hasattr(self, "plotIm") and self.plotIm is not None:
-            self.plotIm.showUpdatingOverlay("Generating Plot... (update queued)")
+        self.plotIm.showUpdatingOverlay("Generating Plot... (update queued)")
 
     def _on_plot_finished(self, view_snapshot, view_params, ids_map, properties):
         if view_params != self.plot_manager.latest_view_params:
@@ -1268,8 +1259,7 @@ class MainWindow(QMainWindow):
         msg_box.exec()
 
     def _on_plot_idle(self):
-        if hasattr(self, "plotIm") and self.plotIm is not None:
-            self.plotIm.hideUpdatingOverlay()
+        self.plotIm.hideUpdatingOverlay()
 
     def saveSettings(self):
         if self.model.statepoint:

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -130,7 +130,6 @@ class MainWindow(QMainWindow):
         self.plot_manager.plot_idle.connect(self._on_plot_idle)
 
         # Load Plot
-        self.statusBar().showMessage('Generating Plot...')
         self.geometryPanel.update()
         self.tallyPanel.update()
         self.colorDialog.updateDialogValues()
@@ -1248,11 +1247,7 @@ class MainWindow(QMainWindow):
                 self._on_plot_idle()
             return
         view_params = self.model.view_params_payload(view_snapshot)
-        started = self.plot_manager.enqueue(view_snapshot, view_params)
-        if started:
-            self.statusBar().showMessage('Generating Plot...')
-        else:
-            self.statusBar().showMessage('Generating Plot... (update queued)')
+        self.plot_manager.enqueue(view_snapshot, view_params)
 
     def waitForPlotIdle(self, timeout_ms=None):
         if self.plot_manager is not None:

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -434,10 +434,17 @@ class MainWindow(QMainWindow):
         changed = self.model.currentView != self.model.defaultView
         self.restoreAction.setDisabled(not changed)
 
+        toggle_actions = (self.maskingAction, self.highlightingAct,
+                          self.outlineAct, self.overlapAct)
+        # Temporarily block signals to avoid triggering plot update
+        for action in toggle_actions:
+            action.blockSignals(True)
         self.maskingAction.setChecked(self.model.currentView.masking)
         self.highlightingAct.setChecked(self.model.currentView.highlighting)
         self.outlineAct.setChecked(self.model.currentView.outlinesCell)
         self.overlapAct.setChecked(self.model.currentView.color_overlaps)
+        for action in toggle_actions:
+            action.blockSignals(False)
 
         num_previous_views = len(self.model.previousViews)
         self.undoAction.setText('&Undo ({})'.format(num_previous_views))

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import QKeyEvent, QAction
 from PySide6.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
                                QScrollArea, QMessageBox, QFileDialog,
                                QColorDialog, QInputDialog, QWidget,
-                               QGestureEvent, QProgressBar)
+                               QGestureEvent)
 
 import openmc
 import openmc.lib
@@ -115,12 +115,6 @@ class MainWindow(QMainWindow):
         self.coord_label = QLabel()
         self.statusBar().addPermanentWidget(self.coord_label)
         self.coord_label.hide()
-        self.busyIndicator = QProgressBar()
-        self.busyIndicator.setRange(0, 0)
-        self.busyIndicator.setMaximumWidth(self.font_metric.averageCharWidth() * 12)
-        self.busyIndicator.setMaximumHeight(self.font_metric.height())
-        self.busyIndicator.hide()
-        self.statusBar().addPermanentWidget(self.busyIndicator)
 
         self.plot_manager = self.model.plot_manager
         self.plot_manager.plot_started.connect(self._on_plot_started)
@@ -1252,11 +1246,12 @@ class MainWindow(QMainWindow):
         return True
 
     def _on_plot_started(self):
-        self.busyIndicator.show()
-        self.statusBar().showMessage('Generating Plot...')
+        if hasattr(self, "plotIm") and self.plotIm is not None:
+            self.plotIm.showUpdatingOverlay("Generating Plot...")
 
     def _on_plot_queued(self):
-        self.statusBar().showMessage('Generating Plot... (update queued)')
+        if hasattr(self, "plotIm") and self.plotIm is not None:
+            self.plotIm.showUpdatingOverlay("Generating Plot... (update queued)")
 
     def _on_plot_finished(self, view_snapshot, view_params, ids_map, properties):
         if view_params != self.plot_manager.latest_view_params:
@@ -1273,8 +1268,8 @@ class MainWindow(QMainWindow):
         msg_box.exec()
 
     def _on_plot_idle(self):
-        self.busyIndicator.hide()
-        self.statusBar().showMessage('')
+        if hasattr(self, "plotIm") and self.plotIm is not None:
+            self.plotIm.hideUpdatingOverlay()
 
     def saveSettings(self):
         if self.model.statepoint:

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import QKeyEvent, QAction
 from PySide6.QtWidgets import (QApplication, QLabel, QSizePolicy, QMainWindow,
                                QScrollArea, QMessageBox, QFileDialog,
                                QColorDialog, QInputDialog, QWidget,
-                               QGestureEvent)
+                               QGestureEvent, QProgressBar)
 
 import openmc
 import openmc.lib
@@ -56,6 +56,8 @@ class MainWindow(QMainWindow):
         self.model_path = Path(model_path)
         self.threads = threads
         self.default_res = resolution
+        self.plot_manager = None
+        self.busyIndicator = None
 
     def loadGui(self, use_settings_pkl=True):
 
@@ -113,16 +115,27 @@ class MainWindow(QMainWindow):
         self.coord_label = QLabel()
         self.statusBar().addPermanentWidget(self.coord_label)
         self.coord_label.hide()
+        self.busyIndicator = QProgressBar()
+        self.busyIndicator.setRange(0, 0)
+        self.busyIndicator.setMaximumWidth(self.font_metric.averageCharWidth() * 12)
+        self.busyIndicator.setMaximumHeight(self.font_metric.height())
+        self.busyIndicator.hide()
+        self.statusBar().addPermanentWidget(self.busyIndicator)
+
+        self.plot_manager = self.model.plot_manager
+        self.plot_manager.plot_started.connect(self._on_plot_started)
+        self.plot_manager.plot_queued.connect(self._on_plot_queued)
+        self.plot_manager.plot_finished.connect(self._on_plot_finished)
+        self.plot_manager.plot_error.connect(self._on_plot_error)
+        self.plot_manager.plot_idle.connect(self._on_plot_idle)
 
         # Load Plot
         self.statusBar().showMessage('Generating Plot...')
         self.geometryPanel.update()
         self.tallyPanel.update()
         self.colorDialog.updateDialogValues()
-        self.statusBar().showMessage('')
 
-        # Timer allows GUI to render before plot finishes loading
-        QtCore.QTimer.singleShot(0, self.showCurrentView)
+        QtCore.QTimer.singleShot(0, self.requestInitialPlot)
 
         self.plotIm.frozen = False
 
@@ -466,11 +479,14 @@ class MainWindow(QMainWindow):
         cv = self.model.currentView
         # load the view from file
         self.loadViewFile(view_file)
+        self.waitForPlotIdle()
         self.plotIm.saveImage(view_file.replace('.pltvw', ''))
 
     # Menu and shared methods
     def loadModel(self, reload=False, use_settings_pkl=True):
         if reload:
+            if hasattr(self, "plot_manager"):
+                self.plot_manager.wait_for_idle()
             self.resetModels()
         else:
             self.model = PlotModel(use_settings_pkl, self.model_path, self.default_res)
@@ -632,66 +648,48 @@ class MainWindow(QMainWindow):
 
     def applyChanges(self):
         if self.model.activeView != self.model.currentView:
-            self.statusBar().showMessage('Generating Plot...')
-            QApplication.processEvents()
             if self.model.activeView.selectedTally is not None:
                 self.tallyPanel.updateModel()
             self.updateMeshAnnotations()
             self.model.storeCurrent()
             self.model.subsequentViews = []
-            self.plotIm.generatePixmap()
-            self.resetModels()
-            self.showCurrentView()
-            self.statusBar().showMessage('')
+            self.requestPlotUpdate()
         else:
             self.statusBar().showMessage('No changes to apply.', 3000)
 
     def undo(self):
-        self.statusBar().showMessage('Generating Plot...')
-        QApplication.processEvents()
-
+        if not self.model.previousViews:
+            return
         self.model.undo()
-        self.resetModels()
-        self.showCurrentView()
         self.geometryPanel.update()
         self.colorDialog.updateDialogValues()
+        self.requestPlotUpdate()
 
         if not self.model.previousViews:
             self.undoAction.setDisabled(True)
         self.redoAction.setDisabled(False)
-        self.statusBar().showMessage('')
 
     def redo(self):
-        self.statusBar().showMessage('Generating Plot...')
-        QApplication.processEvents()
-
+        if not self.model.subsequentViews:
+            return
         self.model.redo()
-        self.resetModels()
-        self.showCurrentView()
         self.geometryPanel.update()
         self.colorDialog.updateDialogValues()
+        self.requestPlotUpdate()
 
         if not self.model.subsequentViews:
             self.redoAction.setDisabled(True)
         self.undoAction.setDisabled(False)
-        self.statusBar().showMessage('')
 
     def restoreDefault(self):
         if self.model.currentView != self.model.defaultView:
-
-            self.statusBar().showMessage('Generating Plot...')
-            QApplication.processEvents()
-
             self.model.storeCurrent()
             self.model.activeView.adopt_plotbase(self.model.defaultView)
-            self.plotIm.generatePixmap()
-            self.resetModels()
-            self.showCurrentView()
             self.geometryPanel.update()
             self.colorDialog.updateDialogValues()
+            self.requestPlotUpdate()
 
             self.model.subsequentViews = []
-            self.statusBar().showMessage('')
 
     def editBasis(self, basis, apply=False):
         self.model.activeView.basis = basis
@@ -1199,6 +1197,9 @@ class MainWindow(QMainWindow):
             self.shortcutOverlay.resize(self.width(), self.height())
 
     def closeEvent(self, event):
+        if hasattr(self, "plot_manager"):
+            self.plot_manager.wait_for_idle()
+            self.plot_manager.shutdown()
         settings = QtCore.QSettings()
         settings.setValue("mainWindow/Size", self.size())
         settings.setValue("mainWindow/Position", self.pos())
@@ -1212,6 +1213,65 @@ class MainWindow(QMainWindow):
         openmc.lib.finalize()
 
         self.saveSettings()
+
+    def requestInitialPlot(self):
+        self.requestPlotUpdate()
+
+    def requestPlotUpdate(self, view=None):
+        if self.plot_manager is None:
+            if hasattr(self, "model"):
+                self.plot_manager = self.model.plot_manager
+                self.plot_manager.plot_started.connect(self._on_plot_started)
+                self.plot_manager.plot_queued.connect(self._on_plot_queued)
+                self.plot_manager.plot_finished.connect(self._on_plot_finished)
+                self.plot_manager.plot_error.connect(self._on_plot_error)
+                self.plot_manager.plot_idle.connect(self._on_plot_idle)
+            else:
+                return None
+        if view is None:
+            view = self.model.activeView
+        view_snapshot = copy.deepcopy(view)
+        view_params = self.model.view_params_payload(view_snapshot)
+        request_id, started = self.plot_manager.enqueue(view_snapshot, view_params)
+        if started:
+            self.statusBar().showMessage('Generating Plot...')
+        else:
+            self.statusBar().showMessage('Generating Plot... (update queued)')
+        return request_id
+
+    def waitForPlotIdle(self, timeout_ms=None):
+        if hasattr(self, "plot_manager"):
+            return self.plot_manager.wait_for_idle(timeout_ms)
+        return True
+
+    def _on_plot_started(self, request_id):
+        if self.busyIndicator is not None:
+            self.busyIndicator.show()
+        self.statusBar().showMessage('Generating Plot...')
+
+    def _on_plot_queued(self, request_id):
+        self.statusBar().showMessage('Generating Plot... (update queued)')
+
+    def _on_plot_finished(self, request_id, view_snapshot, ids_map, properties):
+        if request_id != self.plot_manager.latest_request_id:
+            return
+        self.model.makePlot(view_snapshot, ids_map, properties)
+        self.resetModels()
+        self.showCurrentView()
+
+    def _on_plot_error(self, request_id, error_msg):
+        if request_id != self.plot_manager.latest_request_id:
+            return
+        msg_box = QMessageBox()
+        msg_box.setText(f"Failed to generate plot:\n\n{error_msg}")
+        msg_box.setIcon(QMessageBox.Warning)
+        msg_box.setStandardButtons(QMessageBox.Ok)
+        msg_box.exec()
+
+    def _on_plot_idle(self):
+        if self.busyIndicator is not None:
+            self.busyIndicator.hide()
+        self.statusBar().showMessage('')
 
     def saveSettings(self):
         if self.model.statepoint:

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1230,6 +1230,15 @@ class MainWindow(QMainWindow):
         if view is None:
             view = self.model.activeView
         view_snapshot = copy.deepcopy(view)
+        if self.model.can_reuse_maps(view_snapshot):
+            request_id = self.plot_manager.new_request_id()
+            self.plot_manager.clear_pending()
+            self.model.makePlot(view_snapshot, self.model.ids_map, self.model.properties)
+            self.resetModels()
+            self.showCurrentView()
+            if not self.plot_manager.is_busy:
+                self._on_plot_idle()
+            return request_id
         view_params = self.model.view_params_payload(view_snapshot)
         request_id, started = self.plot_manager.enqueue(view_snapshot, view_params)
         if started:

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -1226,7 +1226,7 @@ class MainWindow(QMainWindow):
 
     def requestPlotUpdate(self, view=None):
         if self.model is None:
-            return None
+            return
         if self.plot_manager is None:
             self.plot_manager = self.model.plot_manager
             self.plot_manager.plot_started.connect(self._on_plot_started)
@@ -1238,44 +1238,42 @@ class MainWindow(QMainWindow):
             view = self.model.activeView
         view_snapshot = copy.deepcopy(view)
         if self.model.can_reuse_maps(view_snapshot):
-            request_id = self.plot_manager.new_request_id()
+            view_params = self.model.view_params_payload(view_snapshot)
+            self.plot_manager.set_latest_view_params(view_params)
             self.plot_manager.clear_pending()
             self.model.makePlot(view_snapshot, self.model.ids_map, self.model.properties)
             self.resetModels()
             self.showCurrentView()
             if not self.plot_manager.is_busy:
                 self._on_plot_idle()
-            return request_id
+            return
         view_params = self.model.view_params_payload(view_snapshot)
-        request_id, started = self.plot_manager.enqueue(view_snapshot, view_params)
+        started = self.plot_manager.enqueue(view_snapshot, view_params)
         if started:
             self.statusBar().showMessage('Generating Plot...')
         else:
             self.statusBar().showMessage('Generating Plot... (update queued)')
-        return request_id
 
     def waitForPlotIdle(self, timeout_ms=None):
         if self.plot_manager is not None:
             return self.plot_manager.wait_for_idle(timeout_ms)
         return True
 
-    def _on_plot_started(self, request_id):
+    def _on_plot_started(self):
         self.busyIndicator.show()
         self.statusBar().showMessage('Generating Plot...')
 
-    def _on_plot_queued(self, request_id):
+    def _on_plot_queued(self):
         self.statusBar().showMessage('Generating Plot... (update queued)')
 
-    def _on_plot_finished(self, request_id, view_snapshot, ids_map, properties):
-        if request_id != self.plot_manager.latest_request_id:
+    def _on_plot_finished(self, view_snapshot, view_params, ids_map, properties):
+        if view_params != self.plot_manager.latest_view_params:
             return
         self.model.makePlot(view_snapshot, ids_map, properties)
         self.resetModels()
         self.showCurrentView()
 
-    def _on_plot_error(self, request_id, error_msg):
-        if request_id != self.plot_manager.latest_request_id:
-            return
+    def _on_plot_error(self, error_msg):
         msg_box = QMessageBox()
         msg_box.setText(f"Failed to generate plot:\n\n{error_msg}")
         msg_box.setIcon(QMessageBox.Warning)

--- a/openmc_plotter/main_window.py
+++ b/openmc_plotter/main_window.py
@@ -134,7 +134,7 @@ class MainWindow(QMainWindow):
         self.tallyPanel.update()
         self.colorDialog.updateDialogValues()
 
-        QtCore.QTimer.singleShot(0, self.requestInitialPlot)
+        QtCore.QTimer.singleShot(0, self.requestPlotUpdate)
 
         self.plotIm.frozen = False
 
@@ -1219,9 +1219,6 @@ class MainWindow(QMainWindow):
         openmc.lib.finalize()
 
         self.saveSettings()
-
-    def requestInitialPlot(self):
-        self.requestPlotUpdate()
 
     def requestPlotUpdate(self, view=None):
         if self.model is None:

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -79,6 +79,8 @@ class PlotImage(FigureCanvas):
                                                   QtCore.QSize()))
 
     def getPlotCoords(self, pos):
+        if not hasattr(self, "ax"):
+            return (0.0, 0.0)
         x, y = self.mouseEventCoords(pos)
 
         # get the normalized axis coordinates from the event display units
@@ -238,6 +240,8 @@ class PlotImage(FigureCanvas):
 
     def mouseMoveEvent(self, event):
         cv = self.model.currentView
+        if not hasattr(self, "ax") or self.model.image is None:
+            return
         # Show Cursor position relative to plot in status bar
         xPlotPos, yPlotPos = self.getPlotCoords(event.pos())
 
@@ -479,9 +483,7 @@ class PlotImage(FigureCanvas):
         if self.frozen:
             return
 
-        self.model.generatePlot()
-        if update:
-            self.updatePixmap()
+        self.main_window.requestPlotUpdate()
 
     def updatePixmap(self):
 
@@ -500,9 +502,8 @@ class PlotImage(FigureCanvas):
                        cv.origin[self.main_window.yBasis] - cv.height/2.,
                        cv.origin[self.main_window.yBasis] + cv.height/2.]
 
-        # make sure we have a domain image to load
-        if not hasattr(self.model, 'image'):
-            self.model.generatePlot()
+        if not hasattr(self.model, 'image') or self.model.image is None:
+            return
 
         ### DRAW DOMAIN IMAGE ###
 

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -38,9 +38,8 @@ class PlotUpdateOverlay(QWidget):
         self.label.setAlignment(QtCore.Qt.AlignCenter)
         font = self.label.font()
         font.setPointSize(max(12, font.pointSize() + 6))
-        font.setWeight(QtGui.QFont.DemiBold)
         self.label.setFont(font)
-        self.label.setStyleSheet("color: white;")
+        self.label.setStyleSheet("color: white; background-color: transparent;")
         layout.addWidget(self.label)
 
         self.hide()

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -2,7 +2,7 @@ from functools import partial
 
 from PySide6 import QtCore, QtGui
 from PySide6.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
-                               QFormLayout, QComboBox, QSpinBox,
+                               QFormLayout, QComboBox, QSpinBox, QLabel,
                                QDoubleSpinBox, QSizePolicy, QMessageBox,
                                QCheckBox, QRubberBand, QMenu, QDialog,
                                QTabWidget, QTableView, QHeaderView)
@@ -19,6 +19,34 @@ from .plotmodel import DomainDelegate, PlotModel
 from .plotmodel import _NOT_FOUND, _VOID_REGION, _OVERLAP, _MODEL_PROPERTIES
 from .scientific_spin_box import ScientificDoubleSpinBox
 from .custom_widgets import HorizontalLine
+
+
+class PlotUpdateOverlay(QWidget):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents, True)
+        self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setStyleSheet("background-color: rgba(20, 20, 20, 140);")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setAlignment(QtCore.Qt.AlignCenter)
+
+        self.label = QLabel("Generating Plot...", self)
+        self.label.setAlignment(QtCore.Qt.AlignCenter)
+        font = self.label.font()
+        font.setPointSize(max(12, font.pointSize() + 6))
+        font.setWeight(QtGui.QFont.DemiBold)
+        self.label.setFont(font)
+        self.label.setStyleSheet("color: white;")
+        layout.addWidget(self.label)
+
+        self.hide()
+
+    def set_message(self, message: str):
+        self.label.setText(message)
 
 
 
@@ -59,6 +87,7 @@ class PlotImage(FigureCanvas):
         self._last_data_indicator_value = None
 
         self.menu = QMenu(self)
+        self.update_overlay = PlotUpdateOverlay(self)
 
     def enterEvent(self, event):
         self.setCursor(QtCore.Qt.CrossCursor)
@@ -121,6 +150,24 @@ class PlotImage(FigureCanvas):
         # resize plot
         self.resize(self.parent.width() * z,
                     self.parent.height() * z)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if self.update_overlay is not None:
+            self.update_overlay.setGeometry(self.rect())
+
+    def showUpdatingOverlay(self, message: str = "Generating Plot..."):
+        if self.update_overlay is None:
+            return
+        self.update_overlay.set_message(message)
+        self.update_overlay.setGeometry(self.rect())
+        self.update_overlay.raise_()
+        self.update_overlay.show()
+
+    def hideUpdatingOverlay(self):
+        if self.update_overlay is None:
+            return
+        self.update_overlay.hide()
 
     def saveImage(self, filename):
         """Save an image of the current view

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -51,6 +51,7 @@ class PlotImage(FigureCanvas):
         self.tally_colorbar = None
         self.tally_image = None
         self.image = None
+        self.ax = None
 
         self._property_colorbar_bg = None
         self._tally_colorbar_bg = None
@@ -79,7 +80,7 @@ class PlotImage(FigureCanvas):
                                                   QtCore.QSize()))
 
     def getPlotCoords(self, pos):
-        if not hasattr(self, "ax"):
+        if self.ax is None:
             return (0.0, 0.0)
         x, y = self.mouseEventCoords(pos)
 
@@ -240,7 +241,7 @@ class PlotImage(FigureCanvas):
 
     def mouseMoveEvent(self, event):
         cv = self.model.currentView
-        if not hasattr(self, "ax") or self.model.image is None:
+        if self.ax is None or self.model.image is None:
             return
         # Show Cursor position relative to plot in status bar
         xPlotPos, yPlotPos = self.getPlotCoords(event.pos())

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -348,6 +348,11 @@ class PlotImage(FigureCanvas):
             self.rubber_band.hide()
             self.main_window.applyChanges()
         else:
+            plot_manager = self.main_window.plot_manager
+            if plot_manager.is_busy or plot_manager.has_pending:
+                return
+            if self.main_window.model.activeView != self.main_window.model.currentView:
+                return
             self.main_window.revertDockControls()
 
     def wheelEvent(self, event):

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -177,10 +177,9 @@ class PlotManager(QObject):
         if self._in_flight_request is None:
             self._pending_request = request
             self._start_next()
-            return True
+            return
         self._pending_request = request
         self.plot_queued.emit()
-        return False
 
     def set_latest_view_params(self, view_params):
         self._latest_view_params = view_params
@@ -480,9 +479,6 @@ class PlotModel:
         if self.ids_map is None or self.properties is None:
             return False
         return self.map_view_params == self.view_params_payload(view)
-
-    def generatePlot(self):
-        self.makePlot()
 
     def makePlot(self, view: Optional["PlotView"] = None,
                  ids_map=None, properties=None):

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -186,6 +186,15 @@ class PlotManager(QObject):
         self.plot_queued.emit(request.request_id)
         return request.request_id, False
 
+    def new_request_id(self):
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        self._latest_request_id = request_id
+        return request_id
+
+    def clear_pending(self):
+        self._pending_request = None
+
     def wait_for_idle(self, timeout_ms: Optional[int] = None):
         if not self.is_busy and not self.has_pending:
             return True
@@ -313,6 +322,7 @@ class PlotModel:
         # Return values from id_map and property_map
         self.ids_map = None
         self.properties = None
+        self.map_view_params = None
 
         self.version = __version__
 
@@ -474,6 +484,11 @@ class PlotModel:
             "color_overlaps": bool(vp.color_overlaps),
         }
 
+    def can_reuse_maps(self, view: "PlotView"):
+        if self.ids_map is None or self.properties is None:
+            return False
+        return self.map_view_params == self.view_params_payload(view)
+
     def generatePlot(self):
         self.makePlot()
 
@@ -494,9 +509,11 @@ class PlotModel:
                 (self.ids_map is None) or (self.properties is None):
                 self.ids_map = openmc.lib.id_map(view.view_params)
                 self.properties = openmc.lib.property_map(view.view_params)
+            self.map_view_params = self.view_params_payload(view)
         else:
             self.ids_map = ids_map
             self.properties = properties
+            self.map_view_params = self.view_params_payload(view)
 
         # update current view
         cv = self.currentView = copy.deepcopy(view)

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -105,20 +105,18 @@ def hash_model(model_path):
 
 @dataclass(frozen=True)
 class PlotRequest:
-    request_id: int
     view_snapshot: "PlotView"
     view_params: Dict[str, object]
 
 
 @dataclass(frozen=True)
 class PlotWorkItem:
-    request_id: int
     view_params: Dict[str, object]
 
 
 class PlotWorker(QObject):
-    finished = Signal(int, object, object)
-    error = Signal(int, str)
+    finished = Signal(object, object, object)
+    error = Signal(str)
 
     @Slot(object)
     def generate_maps(self, work_item: PlotWorkItem):
@@ -133,16 +131,16 @@ class PlotWorker(QObject):
             view_param.color_overlaps = params["color_overlaps"]
             ids_map = openmc.lib.id_map(view_param)
             properties = openmc.lib.property_map(view_param)
-            self.finished.emit(work_item.request_id, ids_map, properties)
+            self.finished.emit(work_item.view_params, ids_map, properties)
         except Exception as exc:
-            self.error.emit(work_item.request_id, str(exc))
+            self.error.emit(str(exc))
 
 
 class PlotManager(QObject):
-    plot_started = Signal(int)
-    plot_queued = Signal(int)
-    plot_finished = Signal(int, object, object, object)
-    plot_error = Signal(int, str)
+    plot_started = Signal()
+    plot_queued = Signal()
+    plot_finished = Signal(object, object, object, object)
+    plot_error = Signal(str)
     plot_idle = Signal()
     work_requested = Signal(object)
 
@@ -159,12 +157,11 @@ class PlotManager(QObject):
 
         self._pending_request = None
         self._in_flight_request = None
-        self._latest_request_id = 0
-        self._next_request_id = 1
+        self._latest_view_params = None
 
     @property
-    def latest_request_id(self):
-        return self._latest_request_id
+    def latest_view_params(self):
+        return self._latest_view_params
 
     @property
     def is_busy(self):
@@ -175,22 +172,18 @@ class PlotManager(QObject):
         return self._pending_request is not None
 
     def enqueue(self, view_snapshot, view_params):
-        request = PlotRequest(self._next_request_id, view_snapshot, view_params)
-        self._next_request_id += 1
-        self._latest_request_id = request.request_id
+        request = PlotRequest(view_snapshot, view_params)
+        self._latest_view_params = view_params
         if self._in_flight_request is None:
             self._pending_request = request
             self._start_next()
-            return request.request_id, True
+            return True
         self._pending_request = request
-        self.plot_queued.emit(request.request_id)
-        return request.request_id, False
+        self.plot_queued.emit()
+        return False
 
-    def new_request_id(self):
-        request_id = self._next_request_id
-        self._next_request_id += 1
-        self._latest_request_id = request_id
-        return request_id
+    def set_latest_view_params(self, view_params):
+        self._latest_view_params = view_params
 
     def clear_pending(self):
         self._pending_request = None
@@ -227,27 +220,26 @@ class PlotManager(QObject):
             return
         self._in_flight_request = self._pending_request
         self._pending_request = None
-        self.plot_started.emit(self._in_flight_request.request_id)
-        work_item = PlotWorkItem(self._in_flight_request.request_id,
-                                 self._in_flight_request.view_params)
+        self.plot_started.emit()
+        work_item = PlotWorkItem(self._in_flight_request.view_params)
         self.work_requested.emit(work_item)
 
-    @Slot(int, object, object)
-    def _on_worker_finished(self, request_id, ids_map, properties):
+    @Slot(object, object, object)
+    def _on_worker_finished(self, view_params, ids_map, properties):
         request = self._in_flight_request
         self._in_flight_request = None
         if request is not None:
-            self.plot_finished.emit(request_id, request.view_snapshot,
-                                    ids_map, properties)
+            self.plot_finished.emit(request.view_snapshot,
+                                    view_params, ids_map, properties)
         if self._pending_request is not None:
             self._start_next()
         else:
             self.plot_idle.emit()
 
-    @Slot(int, str)
-    def _on_worker_error(self, request_id, message):
+    @Slot(str)
+    def _on_worker_error(self, message):
         self._in_flight_request = None
-        self.plot_error.emit(request_id, message)
+        self.plot_error.emit(message)
         if self._pending_request is not None:
             self._start_next()
         else:

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -3,14 +3,15 @@ from ast import literal_eval
 from collections import defaultdict
 import copy
 from ctypes import c_int32, c_char_p
+from dataclasses import dataclass
 import hashlib
 import itertools
 import pickle
-import threading
 from typing import Literal, Tuple, Optional, Dict
 
 from PySide6.QtWidgets import QItemDelegate, QColorDialog, QLineEdit, QMessageBox
-from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt, QSize, QEvent
+from PySide6.QtCore import (QAbstractTableModel, QModelIndex, Qt, QSize, QEvent,
+                            QObject, Signal, Slot, QThread, QEventLoop, QTimer)
 from PySide6.QtGui import QColor
 import openmc
 import openmc.lib
@@ -101,6 +102,147 @@ def hash_model(model_path):
         geom_xml_hash = hash_file(model_path / 'geometry.xml')
     return mat_xml_hash, geom_xml_hash
 
+
+@dataclass(frozen=True)
+class PlotRequest:
+    request_id: int
+    view_snapshot: "PlotView"
+    view_params: Dict[str, object]
+
+
+@dataclass(frozen=True)
+class PlotWorkItem:
+    request_id: int
+    view_params: Dict[str, object]
+
+
+class PlotWorker(QObject):
+    finished = Signal(int, object, object)
+    error = Signal(int, str)
+
+    @Slot(object)
+    def generate_maps(self, work_item: PlotWorkItem):
+        try:
+            params = work_item.view_params
+            view_param = ViewParam(params["origin"], params["width"],
+                                   params["height"], params["h_res"])
+            view_param.h_res = params["h_res"]
+            view_param.v_res = params["v_res"]
+            view_param.basis = params["basis"]
+            view_param.level = params["level"]
+            view_param.color_overlaps = params["color_overlaps"]
+            ids_map = openmc.lib.id_map(view_param)
+            properties = openmc.lib.property_map(view_param)
+            self.finished.emit(work_item.request_id, ids_map, properties)
+        except Exception as exc:
+            self.error.emit(work_item.request_id, str(exc))
+
+
+class PlotManager(QObject):
+    plot_started = Signal(int)
+    plot_queued = Signal(int)
+    plot_finished = Signal(int, object, object, object)
+    plot_error = Signal(int, str)
+    plot_idle = Signal()
+    work_requested = Signal(object)
+
+    def __init__(self):
+        super().__init__()
+        self._thread = QThread()
+        self._worker = PlotWorker()
+        self._worker.moveToThread(self._thread)
+        self._thread.finished.connect(self._worker.deleteLater)
+        self.work_requested.connect(self._worker.generate_maps)
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.error.connect(self._on_worker_error)
+        self._thread.start()
+
+        self._pending_request = None
+        self._in_flight_request = None
+        self._latest_request_id = 0
+        self._next_request_id = 1
+
+    @property
+    def latest_request_id(self):
+        return self._latest_request_id
+
+    @property
+    def is_busy(self):
+        return self._in_flight_request is not None
+
+    @property
+    def has_pending(self):
+        return self._pending_request is not None
+
+    def enqueue(self, view_snapshot, view_params):
+        request = PlotRequest(self._next_request_id, view_snapshot, view_params)
+        self._next_request_id += 1
+        self._latest_request_id = request.request_id
+        if self._in_flight_request is None:
+            self._pending_request = request
+            self._start_next()
+            return request.request_id, True
+        self._pending_request = request
+        self.plot_queued.emit(request.request_id)
+        return request.request_id, False
+
+    def wait_for_idle(self, timeout_ms: Optional[int] = None):
+        if not self.is_busy and not self.has_pending:
+            return True
+        loop = QEventLoop()
+        timer = None
+        if timeout_ms is not None:
+            timer = QTimer()
+            timer.setSingleShot(True)
+            timer.timeout.connect(loop.quit)
+        def on_idle():
+            loop.quit()
+        self.plot_idle.connect(on_idle)
+        if timer is not None:
+            timer.start(timeout_ms)
+        loop.exec()
+        self.plot_idle.disconnect(on_idle)
+        if timer is not None:
+            timer.stop()
+        return not self.is_busy and not self.has_pending
+
+    def shutdown(self):
+        self._pending_request = None
+        self._in_flight_request = None
+        if self._thread.isRunning():
+            self._thread.quit()
+            self._thread.wait()
+
+    def _start_next(self):
+        if self._pending_request is None:
+            return
+        self._in_flight_request = self._pending_request
+        self._pending_request = None
+        self.plot_started.emit(self._in_flight_request.request_id)
+        work_item = PlotWorkItem(self._in_flight_request.request_id,
+                                 self._in_flight_request.view_params)
+        self.work_requested.emit(work_item)
+
+    @Slot(int, object, object)
+    def _on_worker_finished(self, request_id, ids_map, properties):
+        request = self._in_flight_request
+        self._in_flight_request = None
+        if request is not None:
+            self.plot_finished.emit(request_id, request.view_snapshot,
+                                    ids_map, properties)
+        if self._pending_request is not None:
+            self._start_next()
+        else:
+            self.plot_idle.emit()
+
+    @Slot(int, str)
+    def _on_worker_error(self, request_id, message):
+        self._in_flight_request = None
+        self.plot_error.emit(request_id, message)
+        if self._pending_request is not None:
+            self._start_next()
+        else:
+            self.plot_idle.emit()
 
 class PlotModel:
     """Geometry and plot settings for OpenMC Plot Explorer model
@@ -252,6 +394,7 @@ class PlotModel:
             self.currentView = copy.deepcopy(self.defaultView)
 
         self.activeView = copy.deepcopy(self.currentView)
+        self.plot_manager = PlotManager()
 
     def openStatePoint(self, filename):
         self.statepoint = StatePointModel(filename, open_file=True)
@@ -318,29 +461,45 @@ class PlotModel:
         self.activeView.cells = self.defaultView.cells
         self.activeView.materials = self.defaultView.materials
 
-    def generatePlot(self):
-        """ Spawn thread from which to generate new plot image """
-        t = threading.Thread(target=self.makePlot)
-        t.start()
-        t.join()
+    def view_params_payload(self, view: "PlotView"):
+        vp = view.view_params
+        return {
+            "origin": tuple(vp.origin),
+            "width": float(vp.width),
+            "height": float(vp.height),
+            "h_res": int(vp.h_res),
+            "v_res": int(vp.v_res),
+            "basis": str(vp.basis),
+            "level": int(vp.level),
+            "color_overlaps": bool(vp.color_overlaps),
+        }
 
-    def makePlot(self):
+    def generatePlot(self):
+        self.makePlot()
+
+    def makePlot(self, view: Optional["PlotView"] = None,
+                 ids_map=None, properties=None):
         """ Generate new plot image from active view settings
 
         Creates corresponding .xml files from user-chosen settings.
         Runs OpenMC in plot mode to generate new plot image.
         """
+        if view is None:
+            view = self.activeView
         # update/call maps under 2 circumstances
         #   1. this is the intial plot (ids_map/properties are None)
         #   2. The active (desired) view differs from the current view parameters
-        if (self.currentView.view_params != self.activeView.view_params) or \
-            (self.ids_map is None) or (self.properties is None):
-            # get ids from the active (desired) view
-            self.ids_map = openmc.lib.id_map(self.activeView.view_params)
-            self.properties = openmc.lib.property_map(self.activeView.view_params)
+        if ids_map is None or properties is None:
+            if (self.currentView.view_params != view.view_params) or \
+                (self.ids_map is None) or (self.properties is None):
+                self.ids_map = openmc.lib.id_map(view.view_params)
+                self.properties = openmc.lib.property_map(view.view_params)
+        else:
+            self.ids_map = ids_map
+            self.properties = properties
 
         # update current view
-        cv = self.currentView = copy.deepcopy(self.activeView)
+        cv = self.currentView = copy.deepcopy(view)
 
         # set model ids based on domain
         if cv.colorby == 'cell':
@@ -396,7 +555,9 @@ class PlotModel:
             minmax[prop] = (np.min(np.nan_to_num(prop_data)),
                             np.max(np.nan_to_num(prop_data)))
 
-        self.activeView.data_minmax = minmax
+        cv.data_minmax = minmax
+        if self.activeView.view_params == cv.view_params:
+            self.activeView.data_minmax = minmax
 
     def undo(self):
         """ Revert to previous PlotView instance. Re-generate plot image """
@@ -404,7 +565,6 @@ class PlotModel:
         if self.previousViews:
             self.subsequentViews.append(copy.deepcopy(self.currentView))
             self.activeView = self.previousViews.pop()
-            self.generatePlot()
 
     def redo(self):
         """ Revert to subsequent PlotView instance. Re-generate plot image """
@@ -412,7 +572,6 @@ class PlotModel:
         if self.subsequentViews:
             self.storeCurrent()
             self.activeView = self.subsequentViews.pop()
-            self.generatePlot()
 
     def getExternalSourceSites(self, n=100):
         """Plot source sites from a source file

--- a/tests/setup_test/test.py
+++ b/tests/setup_test/test.py
@@ -20,6 +20,7 @@ def test_window(tmpdir, qtbot):
     mw.loadGui()
 
     try:
+        assert mw.waitForPlotIdle(60000)
         mw.saveImage(tmpdir / 'test.png')
 
         qtbot.addWidget(mw)


### PR DESCRIPTION
This change makes plot generation asynchronous so the UI stays responsive during potentially expensive calls into `openmc.lib`. It introduces a background worker thread for `id_map`/`property_map`, queues plot updates, and updates the view when results are ready. A <s>status‑bar busy indicator</s> translucent overlay on the plot provides feedback while plots are generating. Let me know what you think!