### PR TITLE
Overlapping Visualization for Plotter

### DIFF
--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -309,7 +309,10 @@ class PlotImage(FigureCanvas):
         # check that the position is in the axes view
         if 0 <= yPos < self.model.currentView.v_res \
            and 0 <= xPos and xPos < self.model.currentView.h_res:
-            id = self.model.ids[yPos, xPos]
+            if self.model.currentView.colorby == 'cell':
+                id = int(self.model.cell_ids[yPos, xPos])
+            else:
+                id = int(self.model.mat_ids[yPos, xPos])            
             instance = self.model.instances[yPos, xPos]
             temp = "{:g}".format(self.model.property_data[yPos, xPos, 0])
             density = "{:g}".format(self.model.property_data[yPos, xPos, 1])
@@ -355,7 +358,6 @@ class PlotImage(FigureCanvas):
         tallyInfo = ""
 
         if self.parent.underMouse():
-
             if domain_kind.lower() in _MODEL_PROPERTIES:
                 line_val = float(properties[domain_kind.lower()])
                 line_val = max(line_val, 0.0)
@@ -371,46 +373,17 @@ class PlotImage(FigureCanvas):
                 instanceInfo = ""
             if id == _VOID_REGION:
                 domainInfo = ("VOID")
-            elif id == _OVERLAP:
-                x_pix, y_pix = self.getDataIndices(event)
-                cell1, cell2, universe = openmc.lib.slice_data_overlap_info(x_pix, y_pix)
-
-                if len(cell1) > 0:
-                    unique_cells = []
-                    seen = set()
-
-                    for c1, c2 in zip(cell1, cell2):
-                        for cid in (c1, c2):
-                            if cid not in seen:
-                                seen.add(cid)
-                                try:
-                                    cell_obj = self.model.activeView.cells[cid]
-                                    label = f'"{cell_obj.name}"' if cell_obj.name else f'cell {cid}'
-                                except Exception:
-                                    label = f'cell {cid}'
-                                unique_cells.append(label)
-
-                    max_names = 3
-                    if len(unique_cells) <= max_names:
-                        if len(unique_cells) == 1:
-                            domainInfo = f"OVERLAP: {unique_cells[0]}"
-                        elif len(unique_cells) == 2:
-                            domainInfo = f"OVERLAP: {unique_cells[0]} and {unique_cells[1]} have an overlap"
-                        else:
-                            domainInfo = (
-                                "OVERLAP: "
-                                + ", ".join(unique_cells[:-1])
-                                + f", and {unique_cells[-1]} have an overlap"
-                            )
-                    else:
-                        shown = ", ".join(unique_cells[:max_names])
-                        remaining = len(unique_cells) - max_names
-                        domainInfo = (
-                            f"OVERLAP: {shown}, and {remaining} more cells have an overlap"
-                        )
+            elif id < _OVERLAP:
+                # Unpack the index and find it in overlap map
+                overlap_idx = int(_OVERLAP - int(id) - 1)
+                if overlap_idx in self.model.overlap_map:
+                    universe, cell1, cell2 = self.model.overlap_map[overlap_idx]
+                    domainInfo = (
+                        f"OVERLAP: Universe {universe}, "
+                        f"Cells {cell1}/{cell2}"
+                    )
                 else:
-                    domainInfo = "OVERLAP"
-
+                    domainInfo = "OVERLAP (unknown region)"
             elif id != _NOT_FOUND and domain[id].name:
                 domainInfo = ("{} {}{}: \"{}\"\t Density: {} g/cc\t"
                               "Temperature: {} K".format(
@@ -522,7 +495,7 @@ class PlotImage(FigureCanvas):
         self.menu.addAction(self.main_window.redoAction)
         self.menu.addSeparator()
 
-        if int(id) not in (_NOT_FOUND, _OVERLAP) and \
+        if int(id) not in (_NOT_FOUND) and int(id) >= _OVERLAP and \
            cv.colorby not in _MODEL_PROPERTIES:
 
             # Domain ID

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -1,6 +1,5 @@
 import io
 from functools import partial
-import openmc
 
 from PySide6 import QtCore, QtGui
 from PySide6.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
@@ -311,15 +310,7 @@ class PlotImage(FigureCanvas):
            and 0 <= xPos and xPos < self.model.currentView.h_res:
             cell_id = int(self.model.cell_ids[yPos, xPos])
             mat_id = int(self.model.mat_ids[yPos, xPos])
-            if self.model.currentView.colorby == 'cell':
-                id = cell_id
-            else:
-                id = mat_id
-            if id == _OVERLAP:
-                if cell_id < _OVERLAP:
-                    id = cell_id
-                elif mat_id < _OVERLAP:
-                    id = mat_id
+            id = self._domainId(cell_id, mat_id)
             instance = self.model.instances[yPos, xPos]
             temp = "{:g}".format(self.model.property_data[yPos, xPos, 0])
             density = "{:g}".format(self.model.property_data[yPos, xPos, 1])
@@ -347,6 +338,20 @@ class PlotImage(FigureCanvas):
 
         return id, instance, properties, domain, domain_kind
 
+    def _domainId(self, cell_id, mat_id):
+        if self.model.currentView.colorby != 'cell':
+            return mat_id
+        if cell_id == _OVERLAP and mat_id < _OVERLAP:
+            return mat_id
+        return cell_id
+
+    def _cellLabel(self, cell_id):
+        try:
+            name = self.model.activeView.cells[cell_id].name
+        except KeyError:
+            name = None
+        return f"{cell_id} ({name})" if name else str(cell_id)
+
     def _overlapInfo(self, id):
         if id == _OVERLAP:
             return "OVERLAP"
@@ -356,19 +361,9 @@ class PlotImage(FigureCanvas):
             return "OVERLAP (unknown region)"
 
         universe, cell1, cell2 = self.model.overlap_map[overlap_idx]
-        try:
-            name1 = self.model.activeView.cells[cell1].name or str(cell1)
-        except KeyError:
-            name1 = str(cell1)
-        try:
-            name2 = self.model.activeView.cells[cell2].name or str(cell2)
-        except KeyError:
-            name2 = str(cell2)
-
-        return (
-            f"OVERLAP: Universe {universe}, "
-            f"Cells {name1} and {name2}"
-        )
+        label1 = self._cellLabel(cell1)
+        label2 = self._cellLabel(cell2)
+        return f"OVERLAP: Universe {universe}, Cells {label1} and {label2}"
 
     def mouseDoubleClickEvent(self, event):
         xCenter, yCenter = self.getPlotCoords(event.pos())

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -378,9 +378,17 @@ class PlotImage(FigureCanvas):
                 overlap_idx = int(_OVERLAP - int(id) - 1)
                 if overlap_idx in self.model.overlap_map:
                     universe, cell1, cell2 = self.model.overlap_map[overlap_idx]
+                    try:
+                        name1 = self.model.activeView.cells[cell1].name or str(cell1)
+                    except KeyError:
+                        name1 = str(cell1)
+                    try:
+                        name2 = self.model.activeView.cells[cell2].name or str(cell2)
+                    except KeyError:
+                        name2 = str(cell2)
                     domainInfo = (
                         f"OVERLAP: Universe {universe}, "
-                        f"Cells {cell1}/{cell2}"
+                        f"Cells {name1} and {name2}"
                     )
                 else:
                     domainInfo = "OVERLAP (unknown region)"

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -373,7 +373,7 @@ class PlotImage(FigureCanvas):
                 domainInfo = ("VOID")
             elif id == _OVERLAP:
                 x_pix, y_pix = self.getDataIndices(event)
-                cell1, cell2, universe = openmc.lib.slice_plot_overlap_data(x_pix, y_pix)
+                cell1, cell2, universe = openmc.lib.slice_data_overlap_info(x_pix, y_pix)
 
                 if len(cell1) > 0:
                     unique_cells = []

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -310,7 +310,10 @@ class PlotImage(FigureCanvas):
            and 0 <= xPos and xPos < self.model.currentView.h_res:
             cell_id = int(self.model.cell_ids[yPos, xPos])
             mat_id = int(self.model.mat_ids[yPos, xPos])
-            id = self._domainId(cell_id, mat_id)
+            if cell_id < _OVERLAP:
+                id = cell_id
+            else:
+                id = cell_id if self.model.currentView.colorby == 'cell' else mat_id
             instance = self.model.instances[yPos, xPos]
             temp = "{:g}".format(self.model.property_data[yPos, xPos, 0])
             density = "{:g}".format(self.model.property_data[yPos, xPos, 1])
@@ -338,13 +341,6 @@ class PlotImage(FigureCanvas):
 
         return id, instance, properties, domain, domain_kind
 
-    def _domainId(self, cell_id, mat_id):
-        if self.model.currentView.colorby != 'cell':
-            return mat_id
-        if cell_id == _OVERLAP and mat_id < _OVERLAP:
-            return mat_id
-        return cell_id
-
     def _cellLabel(self, cell_id):
         try:
             name = self.model.activeView.cells[cell_id].name
@@ -357,10 +353,10 @@ class PlotImage(FigureCanvas):
             return "OVERLAP"
 
         overlap_idx = int(_OVERLAP - int(id) - 1)
-        if overlap_idx not in self.model.overlap_map:
+        if not 0 <= overlap_idx < len(self.model.overlap_info):
             return "OVERLAP (unknown region)"
 
-        universe, cell1, cell2 = self.model.overlap_map[overlap_idx]
+        universe, cell1, cell2 = self.model.overlap_info[overlap_idx]
         label1 = self._cellLabel(cell1)
         label2 = self._cellLabel(cell2)
         return f"OVERLAP: Universe {universe}, Cells {label1} and {label2}"

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -309,10 +309,17 @@ class PlotImage(FigureCanvas):
         # check that the position is in the axes view
         if 0 <= yPos < self.model.currentView.v_res \
            and 0 <= xPos and xPos < self.model.currentView.h_res:
+            cell_id = int(self.model.cell_ids[yPos, xPos])
+            mat_id = int(self.model.mat_ids[yPos, xPos])
             if self.model.currentView.colorby == 'cell':
-                id = int(self.model.cell_ids[yPos, xPos])
+                id = cell_id
             else:
-                id = int(self.model.mat_ids[yPos, xPos])            
+                id = mat_id
+            if id == _OVERLAP:
+                if cell_id < _OVERLAP:
+                    id = cell_id
+                elif mat_id < _OVERLAP:
+                    id = mat_id
             instance = self.model.instances[yPos, xPos]
             temp = "{:g}".format(self.model.property_data[yPos, xPos, 0])
             density = "{:g}".format(self.model.property_data[yPos, xPos, 1])
@@ -339,6 +346,29 @@ class PlotImage(FigureCanvas):
                       'temperature': temp}
 
         return id, instance, properties, domain, domain_kind
+
+    def _overlapInfo(self, id):
+        if id == _OVERLAP:
+            return "OVERLAP"
+
+        overlap_idx = int(_OVERLAP - int(id) - 1)
+        if overlap_idx not in self.model.overlap_map:
+            return "OVERLAP (unknown region)"
+
+        universe, cell1, cell2 = self.model.overlap_map[overlap_idx]
+        try:
+            name1 = self.model.activeView.cells[cell1].name or str(cell1)
+        except KeyError:
+            name1 = str(cell1)
+        try:
+            name2 = self.model.activeView.cells[cell2].name or str(cell2)
+        except KeyError:
+            name2 = str(cell2)
+
+        return (
+            f"OVERLAP: Universe {universe}, "
+            f"Cells {name1} and {name2}"
+        )
 
     def mouseDoubleClickEvent(self, event):
         xCenter, yCenter = self.getPlotCoords(event.pos())
@@ -373,25 +403,8 @@ class PlotImage(FigureCanvas):
                 instanceInfo = ""
             if id == _VOID_REGION:
                 domainInfo = ("VOID")
-            elif id < _OVERLAP:
-                # Unpack the index and find it in overlap map
-                overlap_idx = int(_OVERLAP - int(id) - 1)
-                if overlap_idx in self.model.overlap_map:
-                    universe, cell1, cell2 = self.model.overlap_map[overlap_idx]
-                    try:
-                        name1 = self.model.activeView.cells[cell1].name or str(cell1)
-                    except KeyError:
-                        name1 = str(cell1)
-                    try:
-                        name2 = self.model.activeView.cells[cell2].name or str(cell2)
-                    except KeyError:
-                        name2 = str(cell2)
-                    domainInfo = (
-                        f"OVERLAP: Universe {universe}, "
-                        f"Cells {name1} and {name2}"
-                    )
-                else:
-                    domainInfo = "OVERLAP (unknown region)"
+            elif id <= _OVERLAP:
+                domainInfo = self._overlapInfo(id)
             elif id != _NOT_FOUND and domain[id].name:
                 domainInfo = ("{} {}{}: \"{}\"\t Density: {} g/cc\t"
                               "Temperature: {} K".format(
@@ -503,8 +516,9 @@ class PlotImage(FigureCanvas):
         self.menu.addAction(self.main_window.redoAction)
         self.menu.addSeparator()
 
-        if int(id) not in (_NOT_FOUND) and int(id) >= _OVERLAP and \
-           cv.colorby not in _MODEL_PROPERTIES:
+        if (int(id) not in (_NOT_FOUND, _VOID_REGION) and
+                int(id) > _OVERLAP and
+                cv.colorby not in _MODEL_PROPERTIES):
 
             # Domain ID
             if domain[id].name:
@@ -571,7 +585,7 @@ class PlotImage(FigureCanvas):
                     connector = partial(self.main_window.editBackgroundColor,
                                         apply=True)
                     bgColorAction.triggered.connect(connector)
-                elif int(id) == _OVERLAP:
+                elif int(id) <= _OVERLAP:
                     olapColorAction = self.menu.addAction(
                         'Edit Overlap Color...')
                     olapColorAction.setToolTip('Edit overlap color')

--- a/openmc_plotter/plotgui.py
+++ b/openmc_plotter/plotgui.py
@@ -1,5 +1,6 @@
 import io
 from functools import partial
+import openmc
 
 from PySide6 import QtCore, QtGui
 from PySide6.QtWidgets import (QWidget, QPushButton, QHBoxLayout, QVBoxLayout,
@@ -371,7 +372,45 @@ class PlotImage(FigureCanvas):
             if id == _VOID_REGION:
                 domainInfo = ("VOID")
             elif id == _OVERLAP:
-                domainInfo = ("OVERLAP")
+                x_pix, y_pix = self.getDataIndices(event)
+                cell1, cell2, universe = openmc.lib.slice_plot_overlap_data(x_pix, y_pix)
+
+                if len(cell1) > 0:
+                    unique_cells = []
+                    seen = set()
+
+                    for c1, c2 in zip(cell1, cell2):
+                        for cid in (c1, c2):
+                            if cid not in seen:
+                                seen.add(cid)
+                                try:
+                                    cell_obj = self.model.activeView.cells[cid]
+                                    label = f'"{cell_obj.name}"' if cell_obj.name else f'cell {cid}'
+                                except Exception:
+                                    label = f'cell {cid}'
+                                unique_cells.append(label)
+
+                    max_names = 3
+                    if len(unique_cells) <= max_names:
+                        if len(unique_cells) == 1:
+                            domainInfo = f"OVERLAP: {unique_cells[0]}"
+                        elif len(unique_cells) == 2:
+                            domainInfo = f"OVERLAP: {unique_cells[0]} and {unique_cells[1]} have an overlap"
+                        else:
+                            domainInfo = (
+                                "OVERLAP: "
+                                + ", ".join(unique_cells[:-1])
+                                + f", and {unique_cells[-1]} have an overlap"
+                            )
+                    else:
+                        shown = ", ".join(unique_cells[:max_names])
+                        remaining = len(unique_cells) - max_names
+                        domainInfo = (
+                            f"OVERLAP: {shown}, and {remaining} more cells have an overlap"
+                        )
+                else:
+                    domainInfo = "OVERLAP"
+
             elif id != _NOT_FOUND and domain[id].name:
                 domainInfo = ("{} {}{}: \"{}\"\t Density: {} g/cc\t"
                               "Temperature: {} K".format(

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -325,7 +325,7 @@ class PlotModel:
         self.map_view_params = None
 
         # Map to be populated by overlap functions
-        self.overlap_map = {}
+        self.overlap_info = None
 
         self.version = __version__
 
@@ -533,16 +533,14 @@ class PlotModel:
                     filter=filter_cpp,
                 )
             self.map_view_params = self.view_params_payload(view)
-                
+
         else:
             self.geom_data = geom_data
             self.property_data = property_data
             self.map_view_params = self.view_params_payload(view)
 
-        overlap_info, n = openmc.lib.slice_data_overlap_info()
-        self.overlap_map = {}
-        for i in range(n):
-            self.overlap_map[i] = (overlap_info[i*3], overlap_info[i*3+1], overlap_info[i*3+2])
+        # Get cell overlap information
+        self.overlap_info = openmc.lib.slice_data_overlap_info()
 
         # update current view
         cv = self.currentView = copy.deepcopy(view)
@@ -557,7 +555,7 @@ class PlotModel:
             domain = cv.materials
             source = self.modelMaterials
 
-        # Normalizes so that domain only sees -3, but 
+        # Normalizes so that domain only sees -3, but
         # overlap indices are still available in cell_ids
         self.ids[self.ids < _OVERLAP] = _OVERLAP  # new line
 

--- a/openmc_plotter/plotmodel.py
+++ b/openmc_plotter/plotmodel.py
@@ -324,6 +324,9 @@ class PlotModel:
         self.property_data = None
         self.map_view_params = None
 
+        # Map to be populated by overlap functions
+        self.overlap_map = {}
+
         self.version = __version__
 
         # default statepoint value
@@ -530,23 +533,33 @@ class PlotModel:
                     filter=filter_cpp,
                 )
             self.map_view_params = self.view_params_payload(view)
+                
         else:
             self.geom_data = geom_data
             self.property_data = property_data
             self.map_view_params = self.view_params_payload(view)
+
+        overlap_info, n = openmc.lib.slice_data_overlap_info()
+        self.overlap_map = {}
+        for i in range(n):
+            self.overlap_map[i] = (overlap_info[i*3], overlap_info[i*3+1], overlap_info[i*3+2])
 
         # update current view
         cv = self.currentView = copy.deepcopy(view)
 
         # set model ids based on domain
         if cv.colorby == 'cell':
-            self.ids = self.cell_ids
+            self.ids = self.cell_ids.copy()
             domain = cv.cells
             source = self.modelCells
         else:
-            self.ids = self.mat_ids
+            self.ids = self.mat_ids.copy()
             domain = cv.materials
             source = self.modelMaterials
+
+        # Normalizes so that domain only sees -3, but 
+        # overlap indices are still available in cell_ids
+        self.ids[self.ids < _OVERLAP] = _OVERLAP  # new line
 
         # generate colors if not present
         for cell_id, cell in cv.cells.items():


### PR DESCRIPTION
This PR includes the plotter-side code corresponding to #3969 in the OpenMC main branch, allowing the plotter to use the information received from the C API via `openmc.lib.slice_data_overlap_info()`. A simple input file will be included for visualization purposes of overlapping regions with the plotter. 
[overlap_test.py](https://github.com/user-attachments/files/29607103/overlap_test.py)


**Changes**

- `getIDinfo`: Read hover IDs directly from cell_ids/mat_ids (i.e. raw geom_data) instead of the processed self.ids. This preserves the encoded overlap index (e.g. -4, -5) which is needed to look up the correct entry in overlap_map.
- `mouseMoveEvent:` Checks `elif id < _OVERLAP`, which decodes the overlap index via `_OVERLAP - id - 1` and looks it up in `overlap_map` to display universe and cell info. Cell names are shown if available, falling back to IDs.
- `contextMenuEvent`: Change `id not in (_NOT_FOUND, _OVERLAP)` to `id >= _OVERLAP` so that overlap pixels (which now carry values more negative than -3) are correctly excluded from the domain color/mask/highlight context menu.
- `overlap_map`: Initialized to {} at model construction and populated after every `makePlot` call by reading `slice_data_overlap_info()`. 
- `self.ids` is now a copy of cell_ids/mat_ids rather than a direct reference. This is necessary because the normalization step mutates the array in place — without the copy it would corrupt `geom_data` itself, breaking the raw index lookups in `getIDinfo`.
- Normalization: `self.ids[self.ids < _OVERLAP] = _OVERLAP` clamps all encoded overlap indices down to -3 in `self.ids`. This is required because `self.ids` is used for image construction via `domain[id].color`, and `DomainViewDict` only has entries for real domain IDs plus the sentinel values `_OVERLAP`, `_NOT_FOUND`, and `_VOID_REGION` — passing -4, -5, etc. would raise a `KeyError`. The raw values are still accessible via cell_ids/mat_ids for hover lookup.